### PR TITLE
Add references to connect-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ for field in user:
 - [Writing plugins](https://protobufpy.com/writing-plugins/)
 - [API reference](https://protobufpy.com/api/)
 - [Code example](./examples/protobuf) — A working example that uses Protobuf to manage a persistent list of users.
+- [Connect for Python](https://github.com/connectrpc/connect-py) — RPC clients and servers built on `protobuf-py`.
 
 ## Packages
 

--- a/docs/generated-code/features.md
+++ b/docs/generated-code/features.md
@@ -10,6 +10,8 @@ for service in example_pb.desc().services:
     print(service.type_name)
 ```
 
+For RPC clients and servers built on `protobuf-py`, see [Connect for Python](https://github.com/connectrpc/connect-py).
+
 ## Comments
 
 Comments in `.proto` files become docstrings on the generated Python classes and attributes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,3 +60,8 @@ print(same.to_json())
 **Zero dependencies.** The whole thing runs on Python 3.10+.
 
 [Get started](./getting-started/installation.md)
+
+## Building RPC APIs
+
+`protobuf-py` gives you the message types. To turn your services into working RPC clients and servers, reach for [Connect for Python](https://github.com/connectrpc/connect-py). It builds directly on `protobuf-py` and is the best way to build APIs.
+


### PR DESCRIPTION
The latest release of [connect-py](https://github.com/connectrpc/connect-py) now uses `protobuf-py` by default. This PR updates the `protobuf-py` docs to link to `connect-py` for building with protobuf in python. 