### PR TITLE
Allow passing int values to float fields

### DIFF
--- a/packages/protobuf-py-ext/src/serializer.rs
+++ b/packages/protobuf-py-ext/src/serializer.rs
@@ -726,6 +726,7 @@ fn validate_is_int(value: &Bound<'_, PyAny>) -> PyResult<()> {
 /// Validates that a Python value is a float.
 fn validate_is_float(value: &Bound<'_, PyAny>) -> PyResult<()> {
     value
+        // Extract instead of exact type-cast so ints are also handled
         .extract::<f64>()
         .map_err(|_| PyTypeError::new_err(format!("expected float, got {}", value.get_type())))?;
     Ok(())

--- a/packages/protobuf-py-ext/src/serializer.rs
+++ b/packages/protobuf-py-ext/src/serializer.rs
@@ -726,7 +726,7 @@ fn validate_is_int(value: &Bound<'_, PyAny>) -> PyResult<()> {
 /// Validates that a Python value is a float.
 fn validate_is_float(value: &Bound<'_, PyAny>) -> PyResult<()> {
     value
-        .cast::<PyFloat>()
+        .extract::<f64>()
         .map_err(|_| PyTypeError::new_err(format!("expected float, got {}", value.get_type())))?;
     Ok(())
 }

--- a/tests/test_float.py
+++ b/tests/test_float.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 from __future__ import annotations
 
+import sys
 from math import copysign
+
+import pytest
 
 from .gen.messages_pb import ImplicitFields
 
@@ -30,3 +33,14 @@ def test_negative_zero() -> None:
     assert (
         copysign(1, ImplicitFields.from_binary(negative.to_binary()).float_field) == -1
     )
+
+
+def test_int_coerced() -> None:
+    msg = ImplicitFields(float_field=1)
+    assert ImplicitFields.from_binary(msg.to_binary()).float_field == 1.0
+
+
+def test_int_out_of_range() -> None:
+    msg = ImplicitFields(float_field=int(sys.float_info.max) * 10)
+    with pytest.raises(OverflowError):
+        msg.to_binary()


### PR DESCRIPTION
I think this is mostly required in Python - surprised we could write so many unit tests without running into it accidentally though.