### PR TITLE
Add documentation for init_files option in quickstart

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -38,6 +38,19 @@ plugins:
 ```
 
 This tells `buf` to read `.proto` files from the `proto/` directory and write generated Python files to `src/gen/`.
+By default, `__init__.py` files are populated to create standard Python packages. To create namespace packages
+without them, set the `init_files=false` option.
+
+
+```yaml title="buf.gen.yaml"
+version: v2
+inputs:
+  - directory: proto
+plugins:
+  - local: protoc-gen-py
+    out: src/gen
+    opt: init_files=false
+```
 
 ## Generate
 


### PR DESCRIPTION
This got lost when moving from a framework to plugin option. Thanks @koljafrahm for noticing!