### PR TITLE
Encode compact JSON

### DIFF
--- a/docs/enums.md
+++ b/docs/enums.md
@@ -26,13 +26,13 @@ PhoneType.desc().open   # True (proto3), False (proto2/closed)
 By default, enum values serialize to their string name in ProtoJSON:
 
 ```python
-msg.to_json()   # {"phoneType": "PHONE_TYPE_MOBILE"}
+msg.to_json()   # {"phoneType":"PHONE_TYPE_MOBILE"}
 ```
 
 To serialize as integers instead, pass `print_enums_as_ints=True`:
 
 ```python
-msg.to_json(print_enums_as_ints=True)   # {"phoneType": 1}
+msg.to_json(print_enums_as_ints=True)   # {"phoneType":1}
 ```
 
 See [Serialization](./serialization.md) for the full list of JSON options.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,7 +63,7 @@ Pass `always_emit_implicit=True` to include them:
 ```python
 user = User(first_name="")
 user.to_json()                          # {}
-user.to_json(always_emit_implicit=True) # {"firstName": ""}
+user.to_json(always_emit_implicit=True) # {"firstName":""}
 ```
 
 For more information, see [JSON](./serialization.md#json).
@@ -76,7 +76,7 @@ The Protobuf JSON specification requires `lowerCamelCase` field names.
 Pass `use_proto_field_name=True` to use the original `snake_case` names instead:
 
 ```python
-user.to_json(use_proto_field_name=True)   # {"first_name": "Homer"}
+user.to_json(use_proto_field_name=True)   # {"first_name":"Homer"}
 ```
 
 Note: if you rename a field in the `.proto` file, JSON consumers will break because JSON uses names, not field numbers.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -139,7 +139,7 @@ Field names are converted to camelCase per the Protobuf JSON specification:
 ```python
 # Serialize to a JSON string
 text: str = user.to_json()
-# {"firstName": "Homer", "lastName": "Simpson", ...}
+# {"firstName":"Homer","lastName":"Simpson",...}
 
 # Deserialize from a JSON string
 user = User.from_json(text)

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -58,7 +58,7 @@ Set this to `True` to always include them:
 ```python
 user = User()   # first_name is "" (zero value)
 user.to_json()  # {} (first_name omitted)
-user.to_json(always_emit_implicit=True)  # {"firstName": ""}
+user.to_json(always_emit_implicit=True)  # {"firstName":""}
 ```
 
 `print_enums_as_ints`: by default, enum values are serialized as string names.
@@ -66,7 +66,7 @@ Set this to `True` to serialize them as integers instead:
 
 ```python
 msg.to_json(print_enums_as_ints=True)
-# {"status": 1} instead of {"status": "ACTIVE"}
+# {"status":1} instead of {"status":"ACTIVE"}
 ```
 
 `use_proto_field_name`: by default, field names are converted to `camelCase` in JSON output.
@@ -74,7 +74,7 @@ Set this to `True` to use the original `snake_case` proto field names instead:
 
 ```python
 user.to_json(use_proto_field_name=True)
-# {"first_name": "Homer"} instead of {"firstName": "Homer"}
+# {"first_name":"Homer"} instead of {"firstName":"Homer"}
 ```
 
 `registry`: required when the message contains a [`google.protobuf.Any`](./well-known-types.md#any) field or extensions.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -303,8 +303,8 @@ print(user2)
 
 ```shellsession
 $ uv run python main.py
-57
-{"firstName": "Yogi", "lastName": "Bear", "active": true}
+52
+{"firstName":"Yogi","lastName":"Bear","active":true}
 Yogi
 Bear
 True
@@ -466,7 +466,7 @@ print(user.to_json())
 
 ```shellsession
 $ uv run python main.py
-{"firstName": "Yogi", "lastName": "Bear", "displayName": "Yabba", "status": "STATUS_ACTIVE", "homeAddress": {"location": "123 Main St", "city": "Jellystone", "country": "USA"}, "workAddress": {"location": "456 Park Ave", "city": "Jellystone", "country": "USA"}, "manager": {"firstName": "Ranger", "lastName": "Smith"}, "hobbies": ["picnicking", "fishing"], "externalUsernames": {"twitter": "@yogibear", "github": "yogidev"}, "sessionTimeoutMinutes": 30, "created": "1958-09-29T18:00:00Z"}
+{"firstName":"Yogi","lastName":"Bear","displayName":"Yabba","status":"STATUS_ACTIVE","homeAddress":{"location":"123 Main St","city":"Jellystone","country":"USA"},"workAddress":{"location":"456 Park Ave","city":"Jellystone","country":"USA"},"manager":{"firstName":"Ranger","lastName":"Smith"},"hobbies":["picnicking","fishing"],"externalUsernames":{"twitter":"@yogibear","github":"yogidev"},"sessionTimeoutMinutes":30,"created":"1958-09-29T18:00:00Z"}
 ```
 
 We see typical Python usage for primitives, enums, submessages, lists, and dicts.

--- a/src/protobuf/_to_json.py
+++ b/src/protobuf/_to_json.py
@@ -210,7 +210,9 @@ def _message_to_json_value(message: Message, opts: ToJsonOptions) -> JsonValue:
 
 
 def to_json(message: Message, opts: ToJsonOptions) -> str:
-    return json.dumps(_message_to_json_value(message, opts))
+    return json.dumps(
+        _message_to_json_value(message, opts), separators=(",", ":"), ensure_ascii=False
+    )
 
 
 def message_to_json_value(


### PR DESCRIPTION
This uses the most compact encoding for JSON, with no spaces around separators and no escaped printable unicode. This aligns it with protobuf-es which gets similar with JSON.stringify, and seems like a good default to me to be the most compact possible. It probably makes sense to have an `indent` type of parameter similar to protobuf-es but I left it out of this PR to keep it API-agnostic.