### PR TITLE
Allow passing in CLI parameters to plugin run

### DIFF
--- a/src/protobuf/plugin/_run.py
+++ b/src/protobuf/plugin/_run.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import dataclasses
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import IO, TYPE_CHECKING, Any, TypeVar, cast, overload
 
 from protobuf import maximum_supported_edition, minimum_supported_edition
 from protobuf.plugin._file import write
@@ -44,6 +44,9 @@ def run(
     *,
     minimum_edition: int = minimum_supported_edition,
     maximum_edition: int = maximum_supported_edition,
+    args: list[str] | None = None,
+    stdin: IO[bytes] | None = None,
+    stdout: IO[bytes] | None = None,
 ) -> None: ...
 
 
@@ -57,6 +60,9 @@ def run(
     *,
     minimum_edition: int = minimum_supported_edition,
     maximum_edition: int = maximum_supported_edition,
+    args: list[str] | None = None,
+    stdin: IO[bytes] | None = None,
+    stdout: IO[bytes] | None = None,
 ) -> None: ...
 
 
@@ -70,6 +76,9 @@ def run(
     *,
     minimum_edition: int = minimum_supported_edition,
     maximum_edition: int = maximum_supported_edition,
+    args: list[str] | None = None,
+    stdin: IO[bytes] | None = None,
+    stdout: IO[bytes] | None = None,
 ) -> None: ...
 
 
@@ -82,6 +91,9 @@ def run(
     *,
     minimum_edition: int = minimum_supported_edition,
     maximum_edition: int = maximum_supported_edition,
+    args: list[str] | None = None,
+    stdin: IO[bytes] | None = None,
+    stdout: IO[bytes] | None = None,
 ) -> None:
     """Run a protoc plugin.
 
@@ -105,15 +117,27 @@ def run(
             Defaults to the runtime's minimum_supported_edition.
         maximum_edition: Maximum edition supported by this plugin.
             Defaults to the runtime's maximum_supported_edition.
+        args: The command line arguments. Defaults to sys.argv.
+        stdin: The input stream to read the request from. Defaults to sys.stdin.buffer.
+        stdout: The output stream to write the response to. Defaults to sys.stdout.buffer.
     """
+    if args is None:
+        args = sys.argv
+    if stdin is None:
+        stdin = sys.stdin.buffer
+        assert stdin is not None  # noqa: S101
+    if stdout is None:
+        stdout = sys.stdout.buffer
+        assert stdout is not None  # noqa: S101
+
     if generate is None:
         generate = cast("Callable[[Schema[Any]], None]", options_or_generate)
         options: type[DataclassInstance] | Callable[[str], Any] | None = None
     else:
         options = options_or_generate
 
-    if "--version" in sys.argv:
-        sys.stdout.write(f"{name} v{version}\n")
+    if "--version" in args:
+        stdout.write(f"{name} v{version}\n".encode())
         sys.exit(0)
 
     if isinstance(options, type):
@@ -127,7 +151,7 @@ def run(
             )
             raise ValueError(msg)
 
-    req = CodeGeneratorRequest.from_binary(sys.stdin.buffer.read())
+    req = CodeGeneratorRequest.from_binary(stdin.read())
 
     try:
         fw_opts, remaining_parameter = parse_options(_FrameworkOptions, req.parameter)
@@ -163,11 +187,12 @@ def run(
             maximum_edition=maximum_edition,
             file=response_files,
         )
-        sys.stdout.buffer.write(resp.to_binary())
+        stdout.write(resp.to_binary())
 
     except Exception:  # noqa: BLE001
         error_msg = traceback.format_exc()
-        _write_error_response(error_msg)
+        resp = CodeGeneratorResponse(error=error_msg)
+        stdout.write(resp.to_binary())
 
 
 def _parse_plugin_options(
@@ -197,12 +222,6 @@ def _parse_plugin_options(
             raise ValueError(msg)
         return result
     return options(parameter)
-
-
-def _write_error_response(error: str) -> None:
-    """Write an error response to stdout."""
-    resp = CodeGeneratorResponse(error=error)
-    sys.stdout.buffer.write(resp.to_binary())
 
 
 @dataclasses.dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,20 +172,33 @@ class Protoc:
         )
         stdin = io.BytesIO(req_bytes)
         stdout = io.BytesIO()
-        self._monkeypatch.setattr(sys, "argv", [f"protoc-gen-{plugin.name}"])
-        self._monkeypatch.setattr(sys, "stdin", type("stdin", (), {"buffer": stdin})())
-        self._monkeypatch.setattr(
-            sys, "stdout", type("stdout", (), {"buffer": stdout})()
-        )
+        args = [f"protoc-gen-{plugin.name}"]
         kwargs: dict[str, int] = {}
         if plugin.minimum_edition is not None:
             kwargs["minimum_edition"] = plugin.minimum_edition
         if plugin.maximum_edition is not None:
             kwargs["maximum_edition"] = plugin.maximum_edition
         if plugin.options is not None:
-            run(plugin.name, plugin.version, plugin.options, plugin.generate, **kwargs)
+            run(
+                plugin.name,
+                plugin.version,
+                plugin.options,
+                plugin.generate,
+                args=args,
+                stdin=stdin,
+                stdout=stdout,
+                **kwargs,
+            )
         else:
-            run(plugin.name, plugin.version, plugin.generate, **kwargs)
+            run(
+                plugin.name,
+                plugin.version,
+                plugin.generate,
+                args=args,
+                stdin=stdin,
+                stdout=stdout,
+                **kwargs,
+            )
         return CodeGeneratorResponse.from_binary(stdout.getvalue())
 
     def _create_codegen_request(

--- a/tests/plugin/test_run.py
+++ b/tests/plugin/test_run.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import io
-import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -29,13 +28,18 @@ if TYPE_CHECKING:
     from tests.conftest import Protoc
 
 
-def test_version(monkeypatch: pytest.MonkeyPatch) -> None:
-    stdout_capture = io.StringIO()
-    monkeypatch.setattr(sys, "argv", ["protoc-gen-test", "--version"])
-    monkeypatch.setattr(sys, "stdout", stdout_capture)
+def test_version() -> None:
+    stdout = io.BytesIO()
     with pytest.raises(SystemExit):
-        run("protoc-gen-test", "1.2.3", lambda _: None)
-    assert stdout_capture.getvalue() == "protoc-gen-test v1.2.3\n"
+        run(
+            "protoc-gen-test",
+            "1.2.3",
+            lambda _: None,
+            args=["protoc-gen-test", "--version"],
+            stdin=io.BytesIO(),
+            stdout=stdout,
+        )
+    assert stdout.getvalue() == b"protoc-gen-test v1.2.3\n"
 
 
 class TestBasicRun:


### PR DESCRIPTION
When looking at how to make it easier to write tests for downstream plugins, the first idea that came to mind is allow passing in CLI run parameters. I think this is pretty common practice for similar types of entry points, and is definitely much simpler in particular than mocking out stdin/stdout as we can see here.