### PR TITLE
Remove typing-extensions from dependency comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ for field in user:
 | Field assignment (`foo.x = 123`) | ✅ Direct assignment                         | ❌ `CopyFrom()` required                                     | ✅ Direct assignment                                          |
 | `copy.copy()` / `copy.replace()` | ✅                                           | ❌                                                           | ❌                                                            |
 | Global mutable registry          | ✅ Explicit `Registry`                       | ❌ Process-wide singleton behavior                           | ✅ N/A                                                        |
-| Zero dependencies                | ✅                                           | ✅                                                           | ❌ Includes `grpclib`, `python-dateutil`, `typing-extensions` |
+| Zero dependencies                | ✅                                           | ✅                                                           | ❌ Includes `grpclib`, `python-dateutil` |
 
 </details>
 


### PR DESCRIPTION
I thought I had removed this already but it may have been a different file - we shouldn't consider typing-extensions in dependency comparisons since it's more an official backports library (I just noticed Guido is listed as a maintainer on the pypi package, doesn't get more official :-) ) than a third party dependency. Depending on needs, we may end up using it in the future too.