### PR TITLE
Encode into a bytearray for pure Python

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -71,7 +71,7 @@ Unknown fields are preserved through binary round-trips by default, so a message
 
 ## Serialization
 
-Binary serialization is implemented as a single-pass write using a fork/join pattern for nested messages. When entering a sub-message, the writer reserves a placeholder for the length prefix, writes the sub-message content, then backfills the actual length — avoiding the need to pre-compute message sizes or make a second pass over the data.
+Binary serialization is implemented as a single-pass write into one contiguous buffer, using a fork/join pattern for nested messages. When entering a sub-message, the writer records the current position, writes the sub-message content, then inserts the length prefix back at that position — avoiding the need to pre-compute message sizes or make a second pass over the data.
 
 Deserialization uses merge semantics: parsing into an existing message overwrites scalars, recursively merges sub-messages, appends to repeated fields, and merges map entries. This is the behavior required by the protobuf spec and enables patterns like merging partial updates.
 

--- a/src/protobuf/_wire/_binary_writer.py
+++ b/src/protobuf/_wire/_binary_writer.py
@@ -32,66 +32,45 @@ def _append_varint(buf: bytearray, value: int) -> None:
 class BinaryWriter:
     """A writer for serializing Protocol Buffer wire format.
 
-    Length-delimited message fields are handled with `fork()`/`join()` pairs.
-    Each `fork()` opens a new scope — the writing context for one sub-message —
-    and reserves a placeholder for the length varint whose value is not yet
-    known. Each `join()` closes the scope, fills in the placeholder with the
-    actual byte count, and returns to the enclosing scope.
-
-    All scopes share a single flat chunk list. Each chunk is appended exactly
-    once and never moved or copied, giving O(n) total work where n is the
-    number of bytes serialized.
+    All writes append to a single contiguous buffer. Length-delimited message
+    fields are handled with `fork()`/`join()` pairs: `fork()` records the
+    current write position, and once the payload has been written, `join()`
+    knows its byte count and inserts the length varint back at that position.
     """
 
     def __init__(self) -> None:
-        # The output of the writer will be the concatenation of all chunks in this list.
-        self._chunks: list[bytes | bytearray] = []
-
-        # Accumulation buffer for small writes; flushed to _chunks at structural boundaries.
         self._buf: bytearray = bytearray()
 
-        # Number of bytes written in the current scope (resets to 0 on fork()).
-        self._size: int = 0
-
-        # Stack of (placeholder_idx, parent_size): pushed by fork(), popped by join().
-        self._stack: list[tuple[int, int]] = []
-
-    def _flush(self) -> None:
-        """Move the accumulation buffer into _chunks if non-empty, updating size."""
-        if self._buf:
-            self._size += len(self._buf)
-            self._chunks.append(self._buf)
-            self._buf = bytearray()
+        # Write positions of open scopes: pushed by fork(), popped by join().
+        self._stack: list[int] = []
 
     def fork(self) -> None:
         """Open a new scope for a length-delimited sub-message field.
 
-        Reserves a placeholder for the length varint and saves the current
-        scope on the stack. Subsequent writes accumulate into the new scope.
-        Must be paired with a call to join().
+        Reserves one byte for the scope's length varint and records its
+        position, which subsequent writes are measured from. Must be paired
+        with a call to join().
         """
-        self._flush()
-        placeholder_idx = len(self._chunks)
-        self._chunks.append(b"")  # placeholder for the length varint
-        self._stack.append((placeholder_idx, self._size))
-        self._size = 0
+        self._stack.append(len(self._buf))
+        self._buf.append(0)
 
     def join(self) -> None:
         """Close the current scope and finalize the sub-message length.
 
-        Fills the placeholder reserved by `fork()` with the actual byte count of
-        the scope, then restores the enclosing scope.
+        Fills the byte reserved by `fork()` with the byte count of the scope,
+        widening it in place when the length varint needs more than one byte.
         """
         if not self._stack:
             msg = "join() called without a matching fork()"
             raise RuntimeError(msg)
-        self._flush()
-        placeholder_idx, parent_size = self._stack.pop()
-        sub_size = self._size
-        length_varint = bytearray()
-        _append_varint(length_varint, sub_size)
-        self._chunks[placeholder_idx] = length_varint
-        self._size = parent_size + len(length_varint) + sub_size
+        fork_pos = self._stack.pop()
+        length = len(self._buf) - fork_pos - 1
+        if length < 0x80:
+            self._buf[fork_pos] = length
+        else:
+            length_varint = bytearray()
+            _append_varint(length_varint, length)
+            self._buf[fork_pos : fork_pos + 1] = length_varint
 
     def finish(self) -> bytes:
         """Return the serialized bytes.
@@ -102,8 +81,7 @@ class BinaryWriter:
         if self._stack:
             msg = f"finish() called with {len(self._stack)} unclosed fork()"
             raise RuntimeError(msg)
-        self._flush()
-        return b"".join(self._chunks)
+        return bytes(self._buf)
 
     def _varint(self, value: int) -> None:
         _append_varint(self._buf, value)
@@ -204,7 +182,7 @@ class BinaryWriter:
         if value < 0 or value >= (1 << 32):
             msg = f"value out of range for fixed32: {value}"
             raise ValueError(msg)
-        self._buf += struct.pack("<I", value)
+        self._buf.extend(struct.pack("<I", value))
 
     def sfixed32(self, value: int) -> None:
         """Write a signed 32-bit integer in fixed-width format.
@@ -215,7 +193,7 @@ class BinaryWriter:
         if value < -(1 << 31) or value >= (1 << 31):
             msg = f"value out of range for sfixed32: {value}"
             raise ValueError(msg)
-        self._buf += struct.pack("<i", value)
+        self._buf.extend(struct.pack("<i", value))
 
     def fixed64(self, value: int) -> None:
         """Write an unsigned 64-bit integer in fixed-width format.
@@ -226,7 +204,7 @@ class BinaryWriter:
         if value < 0 or value >= (1 << 64):
             msg = f"value out of range for fixed64: {value}"
             raise ValueError(msg)
-        self._buf += struct.pack("<Q", value)
+        self._buf.extend(struct.pack("<Q", value))
 
     def sfixed64(self, value: int) -> None:
         """Write a signed 64-bit integer in fixed-width format.
@@ -237,7 +215,7 @@ class BinaryWriter:
         if value < -(1 << 63) or value >= (1 << 63):
             msg = f"value out of range for sfixed64: {value}"
             raise ValueError(msg)
-        self._buf += struct.pack("<q", value)
+        self._buf.extend(struct.pack("<q", value))
 
     def float_(self, value: float) -> None:
         """Write a 32-bit floating point number.
@@ -245,7 +223,7 @@ class BinaryWriter:
         Args:
             value: The float to encode.
         """
-        self._buf += struct.pack("<f", value)
+        self._buf.extend(struct.pack("<f", value))
 
     def double(self, value: float) -> None:
         """Write a 64-bit floating point number.
@@ -253,7 +231,7 @@ class BinaryWriter:
         Args:
             value: The float to encode.
         """
-        self._buf += struct.pack("<d", value)
+        self._buf.extend(struct.pack("<d", value))
 
     def bytes_(self, value: bytes) -> None:
         """Write a length-delimited byte sequence.
@@ -262,9 +240,7 @@ class BinaryWriter:
             value: The bytes to encode.
         """
         self._varint(len(value))
-        self._flush()
-        self._size += len(value)
-        self._chunks.append(value)
+        self._buf.extend(value)
 
     def raw(self, value: bytes) -> None:
         """Write raw bytes directly to the output without any encoding.
@@ -272,9 +248,7 @@ class BinaryWriter:
         Args:
             value: The raw bytes to write.
         """
-        self._flush()
-        self._size += len(value)
-        self._chunks.append(value)
+        self._buf.extend(value)
 
     def string(self, value: str) -> None:
         """Write a length-delimited UTF-8 string.

--- a/src/protobuf/_wire/_binary_writer.py
+++ b/src/protobuf/_wire/_binary_writer.py
@@ -70,6 +70,9 @@ class BinaryWriter:
         else:
             length_varint = bytearray()
             _append_varint(length_varint, length)
+            # Python idiom for inserting any number of bytes into a slot in a
+            # buffer. Results in efficiently copying the existing bytes
+            # before copying in the length.
             self._buf[fork_pos : fork_pos + 1] = length_varint
 
     def finish(self) -> bytes:


### PR DESCRIPTION
I had originally wanted to use a bytearray buffer for this to keep things simplest but we thought protobuf-es's approach is faster enough to be worth it. Now after https://github.com/bufbuild/protobuf-es/pull/1108 it seems we have found it isn't the case :-) So I have brought this to align with it. ~5% faster, but more importantly the code is much simpler (well, it does rely on the slightly tricky fact that `buf[pos:pos+1] = foo` pushes the existing content to the side automagically)

```
---------------------------------------------------------------------------------------- benchmark 'test_serialize _id=buffa:log_record.pb:log_record:0': 2 tests ----------------------------------------------------------------------------------------
Name (time in us)                                                                       Min                 Max               Mean             StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_serialize[bufbuild-python-buffa:log_record.pb:log_record:0] (0001_531aa53)     17.4581 (1.10)     749.5000 (9.20)     18.6798 (1.11)     10.6318 (5.30)     18.1673 (1.10)     0.3749 (1.0)        51;509       53.5337 (0.90)       9616           1
test_serialize[bufbuild-python-buffa:log_record.pb:log_record:0] (0002_2928d23)     15.9163 (1.0)       81.5000 (1.0)      16.8268 (1.0)       2.0077 (1.0)      16.5408 (1.0)      0.4163 (1.11)      425;746       59.4291 (1.0)       11148           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```