### PR TITLE
Add property-based test and workaround PyPy JSON bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .coverage
 .DS_Store
+.hypothesis
 .env
 .vscode
 .mypy_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev-required = [
   "upstream-protobuf",
 
   "buf-bin==1.72.0",
+  "hypothesis==6.164.0",
   "license-header==0.0.1",
   "poethepoet==0.48.0",
   "protoc-runner==35.1",
@@ -363,7 +364,7 @@ addopts = [
 ]
 # Turn all warnings into errors
 filterwarnings = ["error"]
-norecursedirs = ["_gen", "gen"]
+norecursedirs = [".*", "_gen", "gen"]
 testpaths = ["src/protobuf", "tests"]
 
 ## Ruff

--- a/src/protobuf/_to_json.py
+++ b/src/protobuf/_to_json.py
@@ -211,6 +211,7 @@ def _message_to_json_value(message: Message, opts: ToJsonOptions) -> JsonValue:
 
 # PyPy's json.dumps with ensure_ascii=False has a bug that sometimes
 # returns corrupted UTF-8 strings.
+# https://github.com/pypy/pypy/issues/5547
 _ENSURE_ASCII = sys.implementation.name == "pypy"
 
 

--- a/src/protobuf/_to_json.py
+++ b/src/protobuf/_to_json.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import math
+import sys
 from base64 import b64encode
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -208,9 +209,16 @@ def _message_to_json_value(message: Message, opts: ToJsonOptions) -> JsonValue:
     return result
 
 
+# PyPy's json.dumps with ensure_ascii=False has a bug that sometimes
+# returns corrupted UTF-8 strings.
+_ENSURE_ASCII = sys.implementation.name == "pypy"
+
+
 def to_json(message: Message, opts: ToJsonOptions) -> str:
     return json.dumps(
-        _message_to_json_value(message, opts), separators=(",", ":"), ensure_ascii=False
+        _message_to_json_value(message, opts),
+        separators=(",", ":"),
+        ensure_ascii=_ENSURE_ASCII,
     )
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -648,3 +648,14 @@ def test_closed_enum_from_json_ignoring_unknown_fields() -> None:
         json.dumps({"closedColorField": 99}), ignore_unknown_fields=True
     )
     assert msg.closed_color_field == ClosedColor.UNSPECIFIED
+
+
+def test_to_json_del_before_multibyte_char() -> None:
+    # Regression test for a PyPy bug found by test_property.py: json.dumps
+    # with ensure_ascii=False returns a str with a corrupted internal UTF-8
+    # buffer when a string contains "\x7f" followed by a multi-byte
+    # character.
+    msg = Scalars(string_field="\x7f\U000625eb")
+    text = msg.to_json()
+    assert text.encode("utf-8").decode("utf-8") == text
+    assert Scalars.from_json(text) == msg

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2025-2026 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from protobuf import Oneof
+
+from .gen.delimited_encoding_pb import DelimitedEncoding
+from .gen.lists_pb import Lists
+from .gen.maps_pb import Maps
+from .gen.messages_pb import MixedFields, Recursive
+from .gen.scalars_pb import Scalars
+
+if TYPE_CHECKING:
+    from protobuf import Message
+
+# Exceptions the parsers are allowed to raise on malformed input. Anything
+# else (or a crash) is a bug.
+_PARSE_ERRORS = (ValueError, EOFError, RecursionError)
+
+_int32 = st.integers(min_value=-(2**31), max_value=2**31 - 1)
+_int64 = st.integers(min_value=-(2**63), max_value=2**63 - 1)
+_uint32 = st.integers(min_value=0, max_value=2**32 - 1)
+_uint64 = st.integers(min_value=0, max_value=2**64 - 1)
+# NaN breaks the equality assertion (NaN != NaN); float32 width keeps
+# 32-bit float fields exactly representable so they round-trip losslessly.
+_double = st.floats(allow_nan=False)
+_float = st.floats(allow_nan=False, width=32)
+
+
+def _maybe(strategy: st.SearchStrategy[Any]) -> st.SearchStrategy[Any]:
+    """Value or None, so field presence is exercised too."""
+    return st.none() | strategy
+
+
+_scalars = st.builds(
+    Scalars,
+    double_field=_maybe(_double),
+    float_field=_maybe(_float),
+    int32_field=_maybe(_int32),
+    int64_field=_maybe(_int64),
+    uint32_field=_maybe(_uint32),
+    uint64_field=_maybe(_uint64),
+    sint32_field=_maybe(_int32),
+    sint64_field=_maybe(_int64),
+    fixed32_field=_maybe(_uint32),
+    fixed64_field=_maybe(_uint64),
+    sfixed32_field=_maybe(_int32),
+    sfixed64_field=_maybe(_int64),
+    bool_field=_maybe(st.booleans()),
+    string_field=_maybe(st.text()),
+    bytes_field=_maybe(st.binary()),
+)
+
+_lists = st.builds(
+    Lists,
+    double_list=st.lists(_double),
+    float_list=st.lists(_float),
+    int32_list=st.lists(_int32),
+    sint64_list=st.lists(_int64),
+    fixed32_list=st.lists(_uint32),
+    bool_list=st.lists(st.booleans()),
+    string_list=st.lists(st.text()),
+    bytes_list=st.lists(st.binary()),
+)
+
+_maps = st.builds(
+    Maps,
+    int32_to_int32=st.dictionaries(_int32, _int32),
+    sint64_to_sint64=st.dictionaries(_int64, _int64),
+    bool_to_bool=st.dictionaries(st.booleans(), st.booleans()),
+    string_to_string=st.dictionaries(st.text(), st.text()),
+    string_to_bytes=st.dictionaries(st.text(), st.binary()),
+    string_to_double=st.dictionaries(st.text(), _double),
+)
+
+_recursives = st.recursive(
+    st.builds(Recursive),
+    lambda children: st.builds(
+        Recursive,
+        recursive=_maybe(children),
+        repeated_recursive=st.lists(children, max_size=3),
+        map_recursive=st.dictionaries(st.text(), children, max_size=3),
+    ),
+    max_leaves=10,
+)
+
+_oneofs = st.one_of(
+    st.builds(Oneof, field=st.just("oneof_field"), value=st.text()),
+    st.builds(Oneof, field=st.just("oneof_baz"), value=_int32),
+)
+
+_mixed_fields = st.builds(
+    MixedFields,
+    explicit_field=_maybe(_int32),
+    implicit_field=_int32,
+    repeated_field=st.lists(st.text()),
+    message_field=_maybe(st.builds(MixedFields.Bar, value=_maybe(st.text()))),
+    field_with_default=_maybe(_int32),
+    map_field=st.dictionaries(st.text(), _int32),
+    oneof_group=_maybe(_oneofs),
+    implicit_enum_field=st.sampled_from(MixedFields.E),
+    explicit_enum_field=_maybe(st.sampled_from(MixedFields.E)),
+)
+
+_messages = st.one_of(_scalars, _lists, _maps, _recursives, _mixed_fields)
+
+
+@settings(deadline=None)
+@given(msg=_messages)
+def test_binary_roundtrip(msg: Message[Any]) -> None:
+    """Serializing and re-parsing any message must reproduce it exactly."""
+    data = msg.to_binary()
+    parsed = type(msg).from_binary(data)
+    assert parsed == msg
+    if isinstance(msg, (Scalars, Lists)):
+        # Map entry order on the wire is unspecified, so re-serialization
+        # is only byte-identical for map-free message types.
+        assert parsed.to_binary() == data
+
+
+@settings(deadline=None)
+@given(msg=_messages)
+def test_json_roundtrip(msg: Message[Any]) -> None:
+    """Serializing to ProtoJSON and re-parsing must reproduce the message."""
+    parsed = type(msg).from_json(msg.to_json())
+    assert parsed == msg
+
+
+@pytest.mark.parametrize(
+    "msg_type", [Scalars, Lists, Maps, Recursive, MixedFields, DelimitedEncoding]
+)
+@settings(deadline=None)
+@given(data=st.binary(max_size=256))
+def test_from_binary_arbitrary_bytes(msg_type: type[Message[Any]], data: bytes) -> None:
+    """Arbitrary bytes must parse or fail cleanly, never crash.
+
+    When garbage happens to parse, serializing the result (unknown fields
+    included) must produce bytes that parse cleanly again. Byte-identical
+    round trips are not asserted here: map entry order on the wire is
+    unspecified, and a fuzzed signaling NaN in a 32-bit float field may be
+    quieted by the float/double conversion on parse.
+    """
+    try:
+        msg = msg_type.from_binary(data)
+    except _PARSE_ERRORS:
+        return
+    msg_type.from_binary(msg.to_binary())

--- a/uv.lock
+++ b/uv.lock
@@ -277,6 +277,79 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.164.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/ac/7b76103bd74d8457e4de0c6a6c3a26ac6327016438bde125e0a3de83a5b8/hypothesis-6.164.0.tar.gz", hash = "sha256:5d63d263d8c71b571638c18d9591f6e34b836c60a12469e9d9105c1c785f00f1", size = 492022, upload-time = "2026-07-30T12:39:49.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/fe/d5b75a55892b33e72945f82efc71f645d29c0bfdb9f00727f7535a52edcc/hypothesis-6.164.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:14b861ac3353f8643b82a3ba76b8a0a54d2a06160c32b9a1f64a8ab41b179089", size = 771561, upload-time = "2026-07-30T12:39:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b0/2f01e9efc7267446bad0e2a68f7472daa174a72553d213b16aefe44b2bda/hypothesis-6.164.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3d8c8bb00a4b86ae90b9ad41f3e1c99d016ec3e64c0ff9d676a4bb7be4f56948", size = 767079, upload-time = "2026-07-30T12:39:23.123Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/26/d7bcd26b58e1df2bd39116b924b2a72676215d9650e68cbff9a629c3ce30/hypothesis-6.164.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e80e3ba8eaf37664eaa0f2625cef120b330b128a7df570210cf8be4f5ae65aaa", size = 1096364, upload-time = "2026-07-30T12:38:49.972Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/17/99fe7ea866935da83444c3ef7885a14fc7349d96ff61c6faebd37ef4edf2/hypothesis-6.164.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8cdf70f821e2d2f3a0bccaab29830aea8aefb63a77806e7e91246fb65a10c8d3", size = 1124963, upload-time = "2026-07-30T12:39:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/38/e8/df08be6296cbc1271d44e81f8ff9dcd6267a07552fb768e0fdc166e93d40/hypothesis-6.164.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcc3743e22b3cffa7267b4bc74d03628606e4a115495728e986a7be220987315", size = 1145886, upload-time = "2026-07-30T12:39:45.612Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/72/d5cf6fbfac40891d4281f630e16a6eb217ff56f97e350a06e0fd9322aa6a/hypothesis-6.164.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:730f09d4afcd8a918b3d589bfb6421e3b41c057aa57652a773ef4f512cc60836", size = 1101181, upload-time = "2026-07-30T12:39:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ff/7ceb002329febffb678b65835ca6e9479a916325d088aadb0210d07f8252/hypothesis-6.164.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9651cb48cb5a995295b442138d15d381547b935dcb0066fca7148a7955347400", size = 1137970, upload-time = "2026-07-30T12:39:16.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8f/c12c697b73ca9ca24d8a913879e3e0a9db86479754c7221554247c701565/hypothesis-6.164.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:51d161d2655dd86143b370c577267b5b7b4c2e8fcb8a3f22c1a787572aad707c", size = 1270184, upload-time = "2026-07-30T12:38:54.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2f/93f1c850c794fc9c80f5e61b3b20652126b865e6f57b348ae530446aadc7/hypothesis-6.164.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e8a250552390128b57e3afe55035ce2c2cb1f6f0919817657854244f071bc5be", size = 1397987, upload-time = "2026-07-30T12:38:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/bab2546325e15e87c8518dfbca263c81dbc35d566c516d66c9da98a38b77/hypothesis-6.164.0-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:570cd51944e1cc3443847d8afa3d17fcf8aac475a1f744c9e7318a5ad7ef5c9f", size = 1270755, upload-time = "2026-07-30T12:38:51.571Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4e/ea97dd39678a42dc5a24e3e2a64d3b950fad9fb1dcce8d7be5afb52a0335/hypothesis-6.164.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3a423e543055b3de5af7a7624c4285422541658367211fa293a3a57dd0ad01ba", size = 1312888, upload-time = "2026-07-30T12:38:30.847Z" },
+    { url = "https://files.pythonhosted.org/packages/44/84/a6f2d5b12b23d65f16eb398750e430065f9d1f40f4418569e3b87ef58d23/hypothesis-6.164.0-cp310-abi3-win32.whl", hash = "sha256:f5e51490b2ce64c66138f24477d83c71b6224ab0ef65700da10187c464b54e94", size = 657401, upload-time = "2026-07-30T12:39:11.581Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d3/c5ee410daa594cac2d3fe1fbe5473f2390e35f4369e168a817e43341ce2f/hypothesis-6.164.0-cp310-abi3-win_amd64.whl", hash = "sha256:c9059dfbb039342b6590bbce207f90e0f9a80fdf45a404c68c2d3e598be78ab3", size = 663566, upload-time = "2026-07-30T12:39:30.27Z" },
+    { url = "https://files.pythonhosted.org/packages/02/43/08818e5df46965d122bbb7945fdd07ff25d150dd6fda2649e5e786e072c9/hypothesis-6.164.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:dfa1bc85784616a95a73df72a0af616ed230b10390a1c904c9097ba8706ce6bc", size = 772278, upload-time = "2026-07-30T12:38:47.266Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e0/deb80f6031a2f7f9e492e14d5db8028c45de018cbd161e9d327c4c2607c4/hypothesis-6.164.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:232efdf023a9f18918199745128adcd0396f9176469ffd82c380f8175b446066", size = 767976, upload-time = "2026-07-30T12:38:32.026Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/0a/a6235b947529ea01793a64c810c956cfca52a6aacde1545dd814fd737f64/hypothesis-6.164.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:360583bca38dbb14438901e27c7d9259ed35023fde301ab4f16515408ce345f4", size = 1096868, upload-time = "2026-07-30T12:39:47.351Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/1e/8d5e6d63abd800af91da4c797bc45fea8be2d73da302f2f79368b39a6083/hypothesis-6.164.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8cd46b24f0f99396d64998126406e2f2fd1f92fe3478007ccc8c51672370759", size = 1146396, upload-time = "2026-07-30T12:39:17.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cd/157945fa5ffe993dcac40bbf8a2b86f0372ae590cdc7e2b2489429b3c0f7/hypothesis-6.164.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:15f4ab9a69c0707dcd2e9320fabb396cdc1094ab8c1b6dadad04d0f73c18509f", size = 1270822, upload-time = "2026-07-30T12:39:21.126Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d9/b80a73241bc7549a42beec1903b4226a2758bb559195e5d8dca1d56ceedf/hypothesis-6.164.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b8168a4ea415b3df962e91ded89c81079618879f70be7a6ed16c95cf19d5e0c4", size = 1313094, upload-time = "2026-07-30T12:39:31.895Z" },
+    { url = "https://files.pythonhosted.org/packages/32/22/18ec1050d301103e2831daa8f1d01ea6480a4dec0f1c51a17827f23aad4c/hypothesis-6.164.0-cp310-cp310-win_amd64.whl", hash = "sha256:64be21b68bcb8f31e76975d6366eab5f544c5c712f69759c4cf596f34965ef36", size = 663413, upload-time = "2026-07-30T12:39:24.792Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/25/eb86342b486f6392e884f3974ff144ae978e4646787250199f11b9d0931b/hypothesis-6.164.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:e0cffc2228f9185e02eb48cfbd8e30ddf9968ccaac55ab1fb70cbda9aad97507", size = 772036, upload-time = "2026-07-30T12:38:22.166Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/15415bd08b9ae221381ae01d6f453055744112b730c4a670b1642fce4b83/hypothesis-6.164.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f19befdb5e2d8ebe42edd0d2150681a97f599af478ed4e5c86f43762d068b760", size = 767811, upload-time = "2026-07-30T12:39:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/89/59624a5c3194c2cabe0ceeb0d14294b093d8e2d712720bc09320ff73d72a/hypothesis-6.164.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef7115077451e893cb2b96cc30066fc1033ee0788f2d85557fc8479f26b4e6eb", size = 1096709, upload-time = "2026-07-30T12:39:08.361Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3a/09d6c06bb24e6099bdfa7bf74d0f22fbb050f02709563d744d705e44f24a/hypothesis-6.164.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dfa97ba4c59014260c07c35fb3447c3c47eb2faedcffcdd76a9a7967fcac4208", size = 1146181, upload-time = "2026-07-30T12:39:06.668Z" },
+    { url = "https://files.pythonhosted.org/packages/59/11/27390692c2529fed8ebd337127b42299f0f5670f66decedb3cc4c1721d3e/hypothesis-6.164.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:900bb366b2be38c01753345cfdec3b7f30b1b274b9ffa0b0c0bfb3fd085278db", size = 1270536, upload-time = "2026-07-30T12:39:03.321Z" },
+    { url = "https://files.pythonhosted.org/packages/43/2a/7021041460601e2711dbb9dc8c5efbefbbbeffb56b52407ae674d02666e5/hypothesis-6.164.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:def37fdb4d4edb9b423e5ae0625f36074063a6ba82a7d3149dd74f59a291ed3b", size = 1313128, upload-time = "2026-07-30T12:38:44.311Z" },
+    { url = "https://files.pythonhosted.org/packages/30/1f/40cf7209663d4a1d760ead952c58dfba7aca168455dfd436b4c1764d935c/hypothesis-6.164.0-cp311-cp311-win_amd64.whl", hash = "sha256:14633b36b646e9a2a611834ac0a26cde245440469708f59668327eb54f202692", size = 663260, upload-time = "2026-07-30T12:39:38.707Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/4942fe3f2f08b920368ed5a2937346259e843e382205513b4a0e70d2de9d/hypothesis-6.164.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6bc3373fe550cf4d7cadb94ceaeb91e431e1418a96b7baa330487366eaa67d3c", size = 773152, upload-time = "2026-07-30T12:38:33.328Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/df/e66d052386a2b6c3e2f3eab32a02d7de3c9c59cd21d5dd58c08ecfa715f0/hypothesis-6.164.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2780297ca68929b153eff7effb2ebe67e9487d2fd9f49fa961007f8f2d236c9e", size = 764713, upload-time = "2026-07-30T12:38:48.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d5/5a50d14b8f04809e973c4dea884b367fef3663ff253c1205fa9e96229ef9/hypothesis-6.164.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b400bb4eb5a4a1e19cd5af3cc63817909e6b54b4603e04022bdba46860913d7", size = 1095160, upload-time = "2026-07-30T12:38:58.925Z" },
+    { url = "https://files.pythonhosted.org/packages/58/01/781b19ce4382ec239c4dc6ec3bd9f195e69e5570f2814bbf04b5781ecb18/hypothesis-6.164.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fca6632933fc506dd96926d9383483e4c0066c7ff62c748d059a3276da761e7", size = 1145199, upload-time = "2026-07-30T12:39:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/64/30e016863515ca01c1c738b05dd50491353d3ccae6432362e56e0c15d0da/hypothesis-6.164.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b9e1f6e89e5ec34735b727f3ce41d12e7f3b8efc162c91c8a225e10b54b504b4", size = 1267980, upload-time = "2026-07-30T12:38:18.733Z" },
+    { url = "https://files.pythonhosted.org/packages/84/23/17eb8d67d59ecd3a820c905fbdf514e371dd7d01631e62a304cdd5793abe/hypothesis-6.164.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:51b0f967f608707b24ed37a298174ae6eec7899bfe3f271d1c3062c39ad66c06", size = 1312181, upload-time = "2026-07-30T12:38:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/42/69/cff9f3cd9524252adda7c8e0e129dfc176e72f64fdf0bf1552d1ea43d78d/hypothesis-6.164.0-cp312-cp312-win_amd64.whl", hash = "sha256:5770df7d518bf867a9379e9081abd9e44db1d15473430e26a0946438c08c5926", size = 660690, upload-time = "2026-07-30T12:38:28.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/729697380a22dc2ce8feae3c64b08bf3bd3c27e99c3706cb9bdac40c6fc8/hypothesis-6.164.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:29e7cb48974cb9fd87602e20625c890385793c6b56c18a957085a9c291f56ef8", size = 773046, upload-time = "2026-07-30T12:39:40.473Z" },
+    { url = "https://files.pythonhosted.org/packages/38/35/72374f02d90dfda198afd8aac6b1e7d1184506f97e62ebcf3d2c1e5bf761/hypothesis-6.164.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1ff8c3819345be8dd15ee6588ee9383869a54c9a3d2232cce5e26b456424135d", size = 764659, upload-time = "2026-07-30T12:38:55.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/75/fb26388915d71e5949b98ccd0c9d95edcbe6b45d0370f177d43633d81ae2/hypothesis-6.164.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33e88be13fac3ff7cb789a0b4cc43d99fb297db085f529fbb363188141c7d5bf", size = 1095078, upload-time = "2026-07-30T12:38:34.677Z" },
+    { url = "https://files.pythonhosted.org/packages/be/63/f6da6e39667d39a1e44c5df82fbe6cff070c29aaffa9beb62a5322e7d8ae/hypothesis-6.164.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2e296d03a77355ce2e1c32e85a636b555edf0ddaaef277f98f1b84fe38a4595", size = 1145015, upload-time = "2026-07-30T12:39:26.487Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c7/55ba09727da3d9a60628c50e31e6083a36f403cb230f5e1a7bd1749a5c39/hypothesis-6.164.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:53698a1b246714539dd0ecc2d556cde613d74e9f7385ec4109e0651ab2d382d6", size = 1268027, upload-time = "2026-07-30T12:38:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/35/4789cade332f799b0e8f2f7ea0fe2aae6157a85e60f74497e316dd17a7e3/hypothesis-6.164.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:004c92c4b869f8e258f0641101b7743cae8420436f4465383f681c086ef95c9d", size = 1311895, upload-time = "2026-07-30T12:39:14.621Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8a/18d85e624f8631aec42daa8a2f07c6edcedb7385b2c0f375ba8a30cbd065/hypothesis-6.164.0-cp313-cp313-win_amd64.whl", hash = "sha256:4878f81fa92a580d3e16b53e64e01a9d9fe1dca5973783558493a003138dbd36", size = 660656, upload-time = "2026-07-30T12:38:37.696Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/06/3c144d427799c7c72befb0bb3b199d419a89b96e1002fd8f0cc94c84ffb7/hypothesis-6.164.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:9110010bdf6deb3ba9134f8ce8b683e8bb0fba108a351045c96d60c410eb6963", size = 773254, upload-time = "2026-07-30T12:38:38.919Z" },
+    { url = "https://files.pythonhosted.org/packages/74/2d/b61a10d9e70df04aa7e8f34efef8e4afe364e8995c59f894e1c35b428214/hypothesis-6.164.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4df103e5d32b47d574c6e857d45361e2cba5a198d6dae4e4ee1bd248b3a2cbfa", size = 764786, upload-time = "2026-07-30T12:38:24.464Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/7f80ac7bdffe78686135311c919534be411d4565c2a5ba38fd389880c553/hypothesis-6.164.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abec95020960c0ed08e5be318d2bcdde79f2c6fc7785e368a9389d31d3e802a", size = 1095578, upload-time = "2026-07-30T12:38:57.422Z" },
+    { url = "https://files.pythonhosted.org/packages/45/f9/97dcbac776bcf33cb4241b52111527821f707b60a84d03d0ea670b09a134/hypothesis-6.164.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b106756cc9abd50ab1632541ea7b7223792d877a084726aa0304237d758181e", size = 1145207, upload-time = "2026-07-30T12:38:23.387Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/df/68184b6f71540435c895cf35ad1d67a3634a887c597ab38d3372c0d20186/hypothesis-6.164.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:11c4aab2ae6757fc4bc3bbf009487e24fd3490365817bbf40b9ec85a7e02fabb", size = 1268357, upload-time = "2026-07-30T12:38:52.946Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/6a6851dc8af89a5c0418937d38456417b2a1fc9db15c992b9cb43d53a7a3/hypothesis-6.164.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4713edecbc0969557ca135769a36d1e524c8e3b7a2b271de48d98fa29f681bf6", size = 1312183, upload-time = "2026-07-30T12:39:28.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/19/83adeb1f8f045bd8a1ab9822d0c3db28b337d37fff01d809fcd6e3ea70f8/hypothesis-6.164.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:e6882d316c390d33c55ec8f1675f35ab238d7c0473ccf8d235c69eaef6c621b9", size = 604771, upload-time = "2026-07-30T12:39:33.579Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/62/fcb48ebfbccdc5b695de175b9d1d344b3688782150f0603124bb70c0891b/hypothesis-6.164.0-cp314-cp314-win_amd64.whl", hash = "sha256:7c3357633b38bca8c927fd90d02b39a0a3f35f24cdbcfb2fb1dcf69a3f63bd85", size = 660570, upload-time = "2026-07-30T12:39:43.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/61/5857da7db0435fa69df658a9eafba62eb8a1319454005ce2a0d97f6f9e4d/hypothesis-6.164.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:53152cb549f52d661c47768d0d12a192ef26a7a9758a7f13b8ec41e8e63d6325", size = 771839, upload-time = "2026-07-30T12:38:26.842Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9c/22292a9dab1c544362d1759244132c7d71a9d9d5eda5d454ec735fba6bd3/hypothesis-6.164.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cee7898ad84b63da6506ae48483bb36f319a25ea4c2b1d2df47d021cc4080c24", size = 763363, upload-time = "2026-07-30T12:38:20.042Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/29/cc0c6e9a065a32f93fe52dde746232f007d2cabf619d4e7b1b37bd34c424/hypothesis-6.164.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0def33f0d236e54144a5218997e4492925144d4615f25fdbb4ac8e47b7b709e6", size = 1094171, upload-time = "2026-07-30T12:39:35.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/59/37040d0776a29d4bc6d0ca9a50ca2755200007e4a8ddc27b010115b69c85/hypothesis-6.164.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:471fd80d70f2df606b1320276168bc2c6007a586124a1d81628264ccb9266f68", size = 1144089, upload-time = "2026-07-30T12:38:43.024Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/10/5235ed3c090a2f12fa15cc1d08e5a36cfa31bc0607c45199b0806e930ab4/hypothesis-6.164.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2eb285756aee62890fd08d6e97cf77651dfe7c093ceac094df52120a7a8dbe68", size = 1266595, upload-time = "2026-07-30T12:39:36.979Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/97/ffc4cee4dfdffe658e839d5f4df72ae3fa7bfea9401550b475d9700e0ee2/hypothesis-6.164.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7c5215b5568968c35c6e124e5a4a8068f80419d6171414ddf735b49e1df1ab59", size = 1310998, upload-time = "2026-07-30T12:38:45.788Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/08/681d4a272cd2812151581c3328e41a80a34e420d676e419a25b4b9dc2291/hypothesis-6.164.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a845e59fae87bb47a6fb84e0d5adb5679b3b55042fc3f8791da91486103cfbf0", size = 660724, upload-time = "2026-07-30T12:38:40.341Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a4/7f41c25a4aa977ddeb79b61df2dd70ab19986356a344ea2b4cf1fc6a85d2/hypothesis-6.164.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:eb43a07578e04c5a66d86b5a9dd6e5eb81280a8c20b14ff456dd57936fecde15", size = 772964, upload-time = "2026-07-30T12:38:41.559Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/80/d09a3b2af2a817e9c91769ac04ea1083f25e177b54311e8389d2d5cb2bf4/hypothesis-6.164.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:c46cd09811f28c286821863565cf07679294221c40aab3c7a593685fb9c725ed", size = 768787, upload-time = "2026-07-30T12:38:29.533Z" },
+    { url = "https://files.pythonhosted.org/packages/60/91/f073c582c8746efae8b7c2218129d335f13f98cd59d70c04a1ac03baa8e1/hypothesis-6.164.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79c209968acd4d6992c6b8d659f27d160d1368656796781a6fe46471dd9383e4", size = 1097680, upload-time = "2026-07-30T12:39:42.144Z" },
+    { url = "https://files.pythonhosted.org/packages/45/6e/fb1a4e43975b811b40eadd55505fa58d04604e8951dfdcad53903913c8bf/hypothesis-6.164.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a28c8c86a6d3dfb4471687e7b274b6159241a1e56cbe88203521bce635c6f084", size = 1147457, upload-time = "2026-07-30T12:39:01.894Z" },
+    { url = "https://files.pythonhosted.org/packages/32/47/340074ec647f799fdc1b17b2b857e8d0ac0192459980717b7d45910133c8/hypothesis-6.164.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04d2bd698fb58ec697f020ebe7b1f8779fc5bf0c910f3dc934c78542790563fa", size = 664358, upload-time = "2026-07-30T12:38:16.722Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -614,6 +687,7 @@ dev = [
     { name = "example" },
     { name = "example-plugin" },
     { name = "fix-protobuf-imports" },
+    { name = "hypothesis" },
     { name = "license-header" },
     { name = "maturin" },
     { name = "poethepoet" },
@@ -640,6 +714,7 @@ dev-required = [
     { name = "buf-bin" },
     { name = "example" },
     { name = "example-plugin" },
+    { name = "hypothesis" },
     { name = "license-header" },
     { name = "poethepoet" },
     { name = "protoc-gen-py" },
@@ -674,6 +749,7 @@ dev = [
     { name = "example", editable = "examples/protobuf" },
     { name = "example-plugin", editable = "examples/plugin" },
     { name = "fix-protobuf-imports", specifier = "==0.1.7" },
+    { name = "hypothesis", specifier = "==6.164.0" },
     { name = "license-header", specifier = "==0.0.1" },
     { name = "maturin", specifier = "==1.14.1" },
     { name = "poethepoet", specifier = "==0.48.0" },
@@ -698,6 +774,7 @@ dev-required = [
     { name = "buf-bin", specifier = "==1.72.0" },
     { name = "example", editable = "examples/protobuf" },
     { name = "example-plugin", editable = "examples/plugin" },
+    { name = "hypothesis", specifier = "==6.164.0" },
     { name = "license-header", specifier = "==0.0.1" },
     { name = "poethepoet", specifier = "==0.48.0" },
     { name = "protoc-gen-py", editable = "packages/protoc-gen-py" },
@@ -1143,6 +1220,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A random property based test can give some good confidence in reliability at pretty low cost (coverage-guided fuzzing, especially with a mixed python / rust project, would have much higher cost).