### PR TITLE
Use a Python-backed global allocator in Rust

### DIFF
--- a/packages/bench/tests/test_bench.py
+++ b/packages/bench/tests/test_bench.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import base64
 import json
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -49,6 +50,8 @@ from bench.gen.rsb.mk48 import mk48_pb
 from bench.gen.suite_pb import Suite
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from google.protobuf.message import Message as GoogleProtobufMessage
     from protobuf import Message, Registry
     from pytest_benchmark.fixture import BenchmarkFixture
@@ -199,6 +202,59 @@ class TestBench:
                 message = _get_google_protobuf_message_instance(typename, impl)
                 message.ParseFromString(payload)
                 benchmark(message.SerializeToString)
+
+    @pytest.mark.parametrize(
+        ("_id", "typename", "payload"), nested_message_external_cases
+    )
+    def test_serialize_threaded(
+        self,
+        _id: str,
+        typename: str,
+        payload: bytes,
+        impl: Impl,
+        registry: Registry,
+        benchmark: BenchmarkFixture,
+    ) -> None:
+        num_threads = 4
+        # Enough iterations per submitted task that executor dispatch overhead
+        # doesn't dominate the serialization work being measured.
+        iterations = 100
+
+        # Each thread serializes its own message instance, mirroring a server
+        # handling independent requests concurrently.
+        serializers: list[Callable[[], bytes]]
+        match impl:
+            case "bufbuild-python" | "bufbuild-rust":
+                message_desc = registry.message(typename)
+                assert message_desc is not None, (
+                    f"Message {typename} not found in registry"
+                )
+                serializers = [
+                    message_desc.type().from_binary(payload).to_binary
+                    for _ in range(num_threads)
+                ]
+            case "google-python" | "google-upb":
+                serializers = []
+                for _ in range(num_threads):
+                    message = _get_google_protobuf_message_instance(typename, impl)
+                    message.ParseFromString(payload)
+                    serializers.append(message.SerializeToString)
+
+        def serialize_many(serialize: Callable[[], bytes]) -> None:
+            for _ in range(iterations):
+                serialize()
+
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+
+            def run() -> None:
+                futures = [
+                    executor.submit(serialize_many, serialize)
+                    for serialize in serializers
+                ]
+                for future in futures:
+                    future.result()
+
+            benchmark(run)
 
     @pytest.mark.parametrize(("_id", "typename", "payload"), all_external_cases)
     def test_parse(

--- a/packages/protobuf-py-ext/src/alloc.rs
+++ b/packages/protobuf-py-ext/src/alloc.rs
@@ -1,0 +1,108 @@
+//! A global allocator backed by `CPython`'s raw memory domain (`PyMem_Raw*`).
+//!
+//! Routing Rust allocations through the interpreter's allocator makes them
+//! visible to `tracemalloc` and other `PyMem_SetAllocator` hooks. On
+//! free-threaded builds it also picks up a thread-scalable allocator without
+//! linking one into the extension. On GIL builds the raw
+//! domain is plain `malloc` — the same allocator Rust uses by default — so
+//! the only cost is a function-pointer indirection on the small number of
+//! Rust allocations per operation, which does not measure in benchmarks.
+//!
+//! `PyMem_Raw*` is not in the limited API before 3.13, so abi3 wheels fall
+//! back to Rust's default allocator and do not show up in tracemalloc.
+
+use std::alloc::{GlobalAlloc, Layout};
+use std::ptr;
+
+use pyo3::ffi;
+
+#[global_allocator]
+static ALLOCATOR: PyMemRaw = PyMemRaw;
+
+struct PyMemRaw;
+
+/// Alignment the raw allocator provides on its own (that of `max_align_t`).
+const RAW_ALIGN: usize = if size_of::<usize>() >= 8 { 16 } else { 8 };
+
+/// Space stashed in front of an over-aligned block to recover the pointer
+/// originally returned by [`ffi::PyMem_RawMalloc`].
+const HEADER: usize = size_of::<*mut u8>();
+
+/// Whether the raw allocator satisfies `layout` directly. Like the standard
+/// library's `System` allocator, also requires `align <= size` because
+/// allocators may align blocks smaller than `max_align_t` less strictly.
+fn direct(layout: Layout) -> bool {
+    layout.align() <= RAW_ALIGN && layout.align() <= layout.size()
+}
+
+/// Allocates a block whose alignment exceeds what the raw allocator
+/// guarantees by over-allocating and stashing the original pointer in the
+/// [`HEADER`] bytes just in front of the returned block.
+unsafe fn alloc_over_aligned(layout: Layout) -> *mut u8 {
+    let Some(total) = layout
+        .size()
+        .checked_add(layout.align())
+        .and_then(|total| total.checked_add(HEADER))
+    else {
+        return ptr::null_mut();
+    };
+    let raw: *mut u8 = unsafe { ffi::PyMem_RawMalloc(total) }.cast();
+    if raw.is_null() {
+        return ptr::null_mut();
+    }
+    let addr = raw.addr() + HEADER;
+    let aligned = addr + (addr.wrapping_neg() & (layout.align() - 1));
+    let block = unsafe { raw.add(aligned - raw.addr()) };
+    // The header slot is only as aligned as the block, which for alignments
+    // below HEADER may not be enough for a pointer-sized write.
+    unsafe { block.sub(HEADER).cast::<*mut u8>().write_unaligned(raw) };
+    block
+}
+
+unsafe impl GlobalAlloc for PyMemRaw {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if direct(layout) {
+            unsafe { ffi::PyMem_RawMalloc(layout.size()) }.cast()
+        } else {
+            unsafe { alloc_over_aligned(layout) }
+        }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if direct(layout) {
+            unsafe { ffi::PyMem_RawCalloc(layout.size(), 1) }.cast()
+        } else {
+            let block = unsafe { alloc_over_aligned(layout) };
+            if !block.is_null() {
+                unsafe { block.write_bytes(0, layout.size()) };
+            }
+            block
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if direct(layout) {
+            unsafe { ffi::PyMem_RawFree(ptr.cast()) };
+        } else {
+            let raw = unsafe { ptr.sub(HEADER).cast::<*mut u8>().read_unaligned() };
+            unsafe { ffi::PyMem_RawFree(raw.cast()) };
+        }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, layout.align()) };
+        if direct(layout) && direct(new_layout) {
+            return unsafe { ffi::PyMem_RawRealloc(ptr.cast(), new_size) }.cast();
+        }
+        // The old and new blocks need different strategies, so move rather
+        // than resize, freeing through the path that matches each layout.
+        let new_ptr = unsafe { self.alloc(new_layout) };
+        if !new_ptr.is_null() {
+            unsafe {
+                ptr::copy_nonoverlapping(ptr, new_ptr, layout.size().min(new_size));
+                self.dealloc(ptr, layout);
+            }
+        }
+        new_ptr
+    }
+}

--- a/packages/protobuf-py-ext/src/lib.rs
+++ b/packages/protobuf-py-ext/src/lib.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+#[cfg(not(Py_LIMITED_API))]
+mod alloc;
 mod attribute_access;
 mod bitset;
 mod constants;


### PR DESCRIPTION
Got this idea reading through https://labs.quansight.org/blog/scaling-numpy-on-free-threaded-python

It's not that hard to define a Rust allocator that uses python's raw memory APIs, which allows

- free-threaded builds to use mimalloc instead of rust's default glibc malloc
- Even on normal builds, a user can enable tracemalloc and get visibility into the memory taken by protobuf operations. When advertising us as the Python-native library, this is actually a pretty cool point I think

The threaded benchmark is not as reliable as others but saw a geomean of 20% improvement just from switching this allocator on 3.15t.

Note, I have proposed to pyo3 to consider including this feature https://github.com/PyO3/pyo3/issues/6268