### PR TITLE
Cleanup passing xfail tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,6 +361,7 @@ addopts = [
 # Turn all warnings into errors
 filterwarnings = ["error"]
 norecursedirs = [".*", "_gen", "gen"]
+strict_xfail = true
 testpaths = ["src/protobuf", "tests"]
 
 ## Ruff

--- a/tests/test_escaping.py
+++ b/tests/test_escaping.py
@@ -45,27 +45,18 @@ if TYPE_CHECKING:
         "list/bar.proto",
         "class/bar.proto",
         "match/bar.proto",
-        pytest.param("0x.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("a b.bar.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("a-b/bar.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("a+b/bar.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("a.b/bar.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param(
-            "__init__/foo.proto", marks=pytest.mark.xfail(reason="not escaped")
-        ),
-        pytest.param("_foo.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param(
-            "__pycache__/foo.proto", marks=pytest.mark.xfail(reason="not escaped")
-        ),
-        pytest.param("__init__.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("café☕.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param(
-            "!\"#$%&'()*,;=?@[\\]^`{|}~.proto",
-            marks=pytest.mark.xfail(reason="not escaped"),
-        ),
-        pytest.param(
-            "__main__/foo.proto", marks=pytest.mark.xfail(reason="not escaped")
-        ),
+        pytest.param("0x.proto"),
+        pytest.param("a b.bar.proto"),
+        pytest.param("a-b/bar.proto"),
+        pytest.param("a+b/bar.proto"),
+        pytest.param("a.b/bar.proto"),
+        pytest.param("__init__/foo.proto"),
+        pytest.param("_foo.proto"),
+        pytest.param("__pycache__/foo.proto"),
+        pytest.param("__init__.proto"),
+        pytest.param("café☕.proto"),
+        pytest.param("!\"#$%&'()*,;=?@[\\]^`{|}~.proto"),
+        pytest.param("__main__/foo.proto"),
     ],
 )
 def test_module_name(generated_names: _Generated, proto_file_path: str) -> None:
@@ -130,11 +121,11 @@ def test_module_name_collision(
         "example.proto",
         "foo/bar.proto",
         "__init__.proto",
-        pytest.param("a-b/bar.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("a+b/bar.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("a b.bar.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("a.b/bar.proto", marks=pytest.mark.xfail(reason="not escaped")),
-        pytest.param("café☕.proto", marks=pytest.mark.xfail(reason="not escaped")),
+        pytest.param("a-b/bar.proto"),
+        pytest.param("a+b/bar.proto"),
+        pytest.param("a b.bar.proto"),
+        pytest.param("a.b/bar.proto"),
+        pytest.param("café☕.proto"),
     ],
 )
 def test_file_descriptor_var_name(
@@ -148,7 +139,6 @@ def test_file_descriptor_var_name(
     assert not keyword.iskeyword(name), f"file descriptor var {name!r} is a keyword"
 
 
-@pytest.mark.xfail(reason="not escaped")
 def test_generated_escaping_is_valid_python() -> None:
     """The generated escaping_pb.py must be valid Python syntax."""
     # TODO #322: once escaping is implemented, remove this test and let pyright catch regressions

--- a/tests/test_escaping.py
+++ b/tests/test_escaping.py
@@ -54,8 +54,20 @@ if TYPE_CHECKING:
         pytest.param("_foo.proto"),
         pytest.param("__pycache__/foo.proto"),
         pytest.param("__init__.proto"),
-        pytest.param("café☕.proto"),
-        pytest.param("!\"#$%&'()*,;=?@[\\]^`{|}~.proto"),
+        pytest.param(
+            "café☕.proto",
+            marks=pytest.mark.xfail(
+                sys.platform == "win32",
+                reason="protoc cannot handle non-ASCII filenames on Windows",
+            ),
+        ),
+        pytest.param(
+            "!\"#$%&'()*,;=?@[\\]^`{|}~.proto",
+            marks=pytest.mark.xfail(
+                sys.platform == "win32",
+                reason="protoc cannot handle non-ASCII filenames on Windows",
+            ),
+        ),
         pytest.param("__main__/foo.proto"),
     ],
 )
@@ -125,7 +137,13 @@ def test_module_name_collision(
         pytest.param("a+b/bar.proto"),
         pytest.param("a b.bar.proto"),
         pytest.param("a.b/bar.proto"),
-        pytest.param("café☕.proto"),
+        pytest.param(
+            "café☕.proto",
+            marks=pytest.mark.xfail(
+                sys.platform == "win32",
+                reason="protoc cannot handle non-ASCII filenames on Windows",
+            ),
+        ),
     ],
 )
 def test_file_descriptor_var_name(


### PR DESCRIPTION
We originally added these to help define our escaping strategy but forgot to cleanup after implementing them. It's because we were missing `strict_xfail` - it's almost always best to set it to prevent forgetting, and if changing to pass should be accepted, it wasn't an xfail in the first place.