### PR TITLE
Pin CI runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,12 +13,15 @@ permissions:
 
 jobs:
   test:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.native-ext && 'ext' || 'standard' }}
-    runs-on: ${{ matrix.os }}-latest
+    name: ${{ matrix.runner }} / ${{ matrix.python-version }} / ${{ matrix.native-ext && 'ext' || 'standard' }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [Ubuntu, MacOS, Windows]
+        runner:
+          - ubuntu-24.04
+          - macos-15
+          - windows-2025
         python-version:
           - "3.10"
           - "3.11"
@@ -87,7 +90,7 @@ jobs:
           ASSERT_MARSHALER_IMPLEMENTATION: python
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0


### PR DESCRIPTION
ci.yaml is the only one we don't pin runners, so pins for consistently - we like to pin for semi-reproducibility, and renovate will bump them