### PR TITLE
Remove handling of duplicates in JSON parsing

### DIFF
--- a/packages/protobuf-py-ext/src/json_parse.rs
+++ b/packages/protobuf-py-ext/src/json_parse.rs
@@ -4,7 +4,7 @@
 //! reference exactly where practical. Registry-backed Any/extension handling
 //! calls the Python `Registry` object directly (never ported to Rust).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use base64::Engine as _;
 use pyo3::{
@@ -109,50 +109,28 @@ fn read_generic_object<'py, R: JsonSource<'py>>(
         )));
     }
 
-    // A known key can only be the field's proto name or its JSON name, so we
-    // don't need to actually copy the JSON string input itself to track.
-    let mut seen_fields: HashMap<u32, bool> = HashMap::new();
-    let mut seen_oneofs: HashMap<String, String> = HashMap::new();
-
+    // Duplicate keys are accepted with last-in-wins semantics (per the
+    // ProtoJSON spec). Because we are streaming values from the JSON, we do not
+    // get "pre-collapsed" duplicates like `json.loads` would provide. So we keep
+    // track of seen field numbers and reset to the default when encountering one.
+    // This also accounts for duplicates with different JSON names.
+    let mut seen: HashSet<u32> = HashSet::new();
     src.for_each_object_key(|key, src| {
-        let entry = marshaler.json_names.get(key).copied();
-        if let Some(entry) = entry {
-            let number = entry.number;
+        if let Some(&number) = marshaler.json_names.get(key) {
             let parser = marshaler
                 .parser
                 .field(number)
                 .ok_or_else(|| PyValueError::new_err("field table lookup failed"))?;
-            if let Some(&prev_is_proto_name) = seen_fields.get(&number) {
-                if prev_is_proto_name == entry.is_proto_name {
-                    // Same key twice.
-                    return Err(PyValueError::new_err(format!("duplicate key: {key}")));
-                }
-                let prev = if prev_is_proto_name {
-                    &parser.name
-                } else {
-                    &parser.json_name
-                };
-                return Err(PyValueError::new_err(format!(
-                    "field set multiple times by {} and {key}",
-                    prev.bind(py).to_str()?
-                )));
+            // A scalar oneof field set to `null` leaves the oneof unset.
+            if parser.oneof_name.is_some()
+                && matches!(parser.value, FieldParserValue::Scalar(_))
+                && src.peek()? == JsonKind::Null
+            {
+                src.next_null()?;
+                return Ok(());
             }
-            seen_fields.insert(number, entry.is_proto_name);
-
-            if let Some(oneof_name) = &parser.oneof_name {
-                let is_scalar = matches!(parser.value, FieldParserValue::Scalar(_));
-                if is_scalar && src.peek()? == JsonKind::Null {
-                    src.next_null()?;
-                    return Ok(());
-                }
-                let oneof_local = oneof_name.bind(py).to_str()?;
-                let field_proto_name = parser.name.bind(py).to_str()?;
-                if let Some(prev) = seen_oneofs.get(oneof_local) {
-                    return Err(PyValueError::new_err(format!(
-                        "oneof set multiple times by {prev} and {field_proto_name}"
-                    )));
-                }
-                seen_oneofs.insert(oneof_local.to_owned(), field_proto_name.to_owned());
+            if merges_on_duplicate(parser) && !seen.insert(number) {
+                reset_duplicate_field(py, parser, message)?;
             }
             read_field(marshaler, parser, message, src, opts, depth)?;
         } else {
@@ -161,6 +139,36 @@ fn read_generic_object<'py, R: JsonSource<'py>>(
         Ok(())
     })?;
     Ok(())
+}
+
+/// Whether a repeat of this field merges into the value already read (repeated
+/// appends, maps add keys, singular messages merge fields) and so must be reset
+/// for last-in-wins.
+fn merges_on_duplicate(parser: &FieldParser) -> bool {
+    match &parser.type_ {
+        ParserFieldType::List { .. } | ParserFieldType::Map { .. } => true,
+        ParserFieldType::Singular { oneof_attr, .. } => {
+            oneof_attr.is_none() && matches!(parser.value, FieldParserValue::Message { .. })
+        }
+    }
+}
+
+/// Resets a field to its default before a duplicate JSON key is applied, so the
+/// later occurrence replaces the earlier one rather than merging into it.
+fn reset_duplicate_field<'py>(
+    py: Python<'py>,
+    parser: &FieldParser,
+    message: &Bound<'py, NativeMessage>,
+) -> PyResult<()> {
+    match &parser.type_ {
+        ParserFieldType::List { .. } => parser.attr.set(message.as_any(), &PyList::empty(py)),
+        ParserFieldType::Map { .. } => parser.attr.set(message.as_any(), &PyDict::new(py)),
+        ParserFieldType::Singular { .. } => {
+            parser.attr.set(message.as_any(), py.None().bind(py))?;
+            message.get().clear_present_field(parser.number);
+            Ok(())
+        }
+    }
 }
 
 fn read_field<'py, R: JsonSource<'py>>(
@@ -359,14 +367,7 @@ fn read_map<'py, R: JsonSource<'py>>(
         .attr
         .get(py, message.as_any())?
         .cast_into::<PyDict>()?;
-    // Duplicates are detected on the raw JSON key,
-    // not the parsed map key: e.g. int keys "3" and "3.0" are distinct raw
-    // keys, so the last entry wins rather than erroring.
-    let mut raw_keys: HashSet<Box<str>> = HashSet::new();
     src.for_each_object_key(|key, src| {
-        if !raw_keys.insert(key.into()) {
-            return Err(PyValueError::new_err(format!("duplicate key: {key}")));
-        }
         let map_key = read_map_key(py, &ctx, key_type, key)?;
         if let Some(value) = read_container_item(&ctx, &value_parser.value, src, opts, depth, true)?
         {

--- a/packages/protobuf-py-ext/src/marshaler.rs
+++ b/packages/protobuf-py-ext/src/marshaler.rs
@@ -49,38 +49,16 @@ struct MessageDefaults {
     dicts: Vec<AttributeAccess>,
 }
 
-/// A JSON object key that resolves to a message field, tagged with which of
-/// the field's two accepted keys (proto name or JSON name) it is.
-#[derive(Clone, Copy)]
-pub(crate) struct JsonKeyEntry {
-    pub(crate) number: u32,
-    pub(crate) is_proto_name: bool,
-}
-
 /// Maps both the proto name and JSON name of every field to its number for
 /// parse-side key lookup.
 fn build_json_names(
     py: Python<'_>,
     fields: &[crate::descriptor::DescField],
-) -> PyResult<HashMap<Box<str>, JsonKeyEntry>> {
+) -> PyResult<HashMap<Box<str>, u32>> {
     let mut json_names = HashMap::with_capacity(fields.len() * 2);
     for field in fields {
-        // When name == json_name the second insert wins; the flag is
-        // irrelevant then since both render the same key text.
-        json_names.insert(
-            field.name.bind(py).to_str()?.into(),
-            JsonKeyEntry {
-                number: field.number,
-                is_proto_name: true,
-            },
-        );
-        json_names.insert(
-            field.json_name.bind(py).to_str()?.into(),
-            JsonKeyEntry {
-                number: field.number,
-                is_proto_name: false,
-            },
-        );
+        json_names.insert(field.name.bind(py).to_str()?.into(), field.number);
+        json_names.insert(field.json_name.bind(py).to_str()?.into(), field.number);
     }
     Ok(json_names)
 }
@@ -106,9 +84,8 @@ pub(crate) struct MessageMarshalerInner {
     pub(crate) wkt: Option<Box<WktKind>>,
 
     /// JSON key lookup for parsing: both the proto field name and the JSON
-    /// name map to the field number, tagged with which of the two the key is
-    /// so duplicate-key errors can render the first key without owning a copy.
-    pub(crate) json_names: HashMap<Box<str>, JsonKeyEntry>,
+    /// name map to the field number.
+    pub(crate) json_names: HashMap<Box<str>, u32>,
 
     /// The default values for each member.
     defaults: MessageDefaults,

--- a/packages/protobuf-py-ext/src/parser.rs
+++ b/packages/protobuf-py-ext/src/parser.rs
@@ -175,7 +175,6 @@ impl ParserFieldType {
                     local_name_py: constants.value.clone_ref(py),
                     local_name: constants.value.extract::<String>(py).unwrap_or_default(),
                     name: constants.value.clone_ref(py),
-                    json_name: constants.value.clone_ref(py),
                     oneof_name: None,
                     attr: AttributeAccess::Name(constants.value.clone_ref(py)),
                 });
@@ -197,8 +196,6 @@ pub(crate) struct FieldParser {
     local_name: String,
     /// The proto field name.
     pub(crate) name: Py<PyString>,
-    /// The JSON name (used with `name` to render duplicate-key errors).
-    pub(crate) json_name: Py<PyString>,
     /// The oneof name this field belongs to, if any.
     pub(crate) oneof_name: Option<Py<PyString>>,
     pub(crate) attr: AttributeAccess,
@@ -235,7 +232,6 @@ impl FieldParser {
             local_name_py: field.local_name.clone_ref(py),
             local_name: field.local_name.extract::<String>(py).unwrap_or_default(),
             name: field.name.clone_ref(py),
-            json_name: field.json_name.clone_ref(py),
             oneof_name: field.value.oneof_name().map(|name| name.clone_ref(py)),
             attr: AttributeAccess::new(py, python_type, field.local_name.bind(py)),
             type_: ParserFieldType::new(py, field, python_type, constants),

--- a/packages/protobuf-py-ext/src/wkt_registry.rs
+++ b/packages/protobuf-py-ext/src/wkt_registry.rs
@@ -1,7 +1,7 @@
 //! Central registry for well-known types to handle special JSON marshaling.
 //! Closely mirrors `_wkt_registry.py`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use buffa::json_helpers::wkt as buffa_wkt;
 use bytes::Bytes;
@@ -370,12 +370,8 @@ impl WktStruct {
             .fields
             .get(py, message.as_any())?
             .cast_into::<PyDict>()?;
-        // Duplicates are detected on the raw JSON key.
-        let mut raw_keys: HashSet<Box<str>> = HashSet::new();
+        // Duplicate keys use last-in-wins semantics (per the ProtoJSON spec).
         src.for_each_object_key(|key, src| {
-            if !raw_keys.insert(key.into()) {
-                return Err(PyValueError::new_err(format!("duplicate key: {key}")));
-            }
             let value_msg =
                 value_marshaler.new_empty_message(py, self.value.get_python_type(py))?;
             read_message(value_marshaler, &value_msg, src, opts, depth + 1)?;

--- a/packages/upstream-protobuf/src/bufbuild/upstream_protobuf/conformance_runner.py
+++ b/packages/upstream-protobuf/src/bufbuild/upstream_protobuf/conformance_runner.py
@@ -39,6 +39,8 @@ def run(output_dir: Path, command: list[str], test: str = "") -> None:
         "--enforce_recommended",
         "--maximum_edition",
         maximum_supported_edition.name.removeprefix("EDITION_"),
+        "--failure_list",
+        output_dir / "failing_tests.txt",
     ]
     if test:
         args.extend(["--test", test])

--- a/src/protobuf/_from_json.py
+++ b/src/protobuf/_from_json.py
@@ -28,9 +28,7 @@ from ._descriptors import (
     DescFieldValueMap,
     DescFieldValueMessage,
     DescFieldValueScalar,
-    DescFieldValueSingular,
     DescMessage,
-    DescOneof,
     ScalarType,
 )
 from ._oneof import Oneof
@@ -112,24 +110,23 @@ def _read_message(msg: Message, json: JsonValue, opts: FromJsonOptions) -> None:
         raise TypeError(err)
 
     desc = msg.__class__._desc
-    seen_oneofs = dict[DescOneof, DescField]()
-    seen_fields = dict[DescField, str]()
+    # A field can be named twice by its proto name and its JSON name (identical
+    # keys are already collapsed to the last value by json.loads). Duplicates
+    # are last-in-wins, so reset the field before applying a later occurrence.
+    seen = set[DescField]()
     for key, value in json.items():
         field = desc._fields_by_json_name.get(key)
         if field:
-            if seen := seen_fields.get(field):
-                err = f"field set multiple times by {seen} and {key}"
-                raise ValueError(err)
-            seen_fields[field] = key
             field_value = field.value
-            if isinstance(field_value, DescFieldValueSingular) and field_value.oneof:
-                if value is None and isinstance(field_value, DescFieldValueScalar):
-                    continue
-                seen = seen_oneofs.get(field_value.oneof)
-                if seen:
-                    err = f"oneof set multiple times by {seen.name} and {field.name}"
-                    raise ValueError(err)
-                seen_oneofs[field_value.oneof] = field
+            if (
+                isinstance(field_value, DescFieldValueScalar)
+                and field_value.oneof
+                and value is None
+            ):
+                continue
+            if field in seen:
+                _reset_duplicate_field(msg, field)
+            seen.add(field)
             _read_field(msg, field, value, opts)
         else:
             extension = None
@@ -146,6 +143,17 @@ def _read_message(msg: Message, json: JsonValue, opts: FromJsonOptions) -> None:
                     f"cannot decode {desc.type_name} from JSON: key: '{key}' is unknown"
                 )
                 raise ValueError(err)
+
+
+def _reset_duplicate_field(msg: Message, field: DescField) -> None:
+    """Clears a field so a duplicate JSON key replaces it instead of merging."""
+    match field.value:
+        case DescFieldValueList() | DescFieldValueMap():
+            msg._get_member(field).clear()
+        case DescFieldValueMessage() if not field.value.oneof:
+            msg._del_member(field)
+        case _:
+            pass
 
 
 def _read_field(
@@ -632,24 +640,6 @@ def _value_from_json(
             msg.kind = Oneof("struct_value", struct)
         case _:
             assert_never(json)
-
-
-def _no_duplicates(pairs: list[tuple[str, JsonValue]]) -> dict[str, JsonValue]:
-    """Reject duplicate JSON keys at parse time via json.loads object_pairs_hook.
-
-    This is needed in addition to the seen_fields check in _read_message
-    because a single proto field can have two distinct JSON keys (its proto
-    name and its json_name). seen_fields catches that case, but it cannot
-    catch two identical JSON keys that map to the same dict entry, since
-    Python's default JSON parser silently keeps only the last value.
-    """
-    obj: dict[str, JsonValue] = {}
-    for k, v in pairs:
-        if k in obj:
-            msg = f"duplicate key: {k}"
-            raise ValueError(msg)
-        obj[k] = v
-    return obj
 
 
 def message_from_json_value(

--- a/src/protobuf/_message.py
+++ b/src/protobuf/_message.py
@@ -683,13 +683,9 @@ class Message(Generic[FieldNamesT], metaclass=MessageMeta):  # noqa: PLW1641
         from json import loads as parse_json  # noqa: PLC0415
 
         # Needs to be lazy import since JSON specially handles many WKTs.
-        from ._from_json import (  # noqa: PLC0415
-            FromJsonOptions,
-            _no_duplicates,
-            _read_message,
-        )
+        from ._from_json import FromJsonOptions, _read_message  # noqa: PLC0415
 
-        json_value = parse_json(json, object_pairs_hook=_no_duplicates)
+        json_value = parse_json(json)
         opts = FromJsonOptions(
             ignore_unknown_fields=ignore_unknown_fields, registry=registry
         )

--- a/tests/conformance/failing_tests.txt
+++ b/tests/conformance/failing_tests.txt
@@ -1,0 +1,21 @@
+# These tests do not actually match the ProtoJSON spec of allowing last-in-wins handling of duplicates.
+# The tests have been fixed in https://github.com/protocolbuffers/protobuf/pull/28903
+# and to improve JSON parsing performance before that is released in v37, we go ahead and accept these
+# failures. We have ad-hoc confirmed building the conformance runner from main clears this file so
+# consider this to not break our policy of full-conformance.
+Recommended.Editions_Proto2.JsonInput.FieldNameDuplicate # Should have failed to parse, but didn't.
+Recommended.Editions_Proto2.JsonInput.FieldNameDuplicateDifferentCasing1 # Should have failed to parse, but didn't.
+Recommended.Editions_Proto2.JsonInput.FieldNameDuplicateDifferentCasing2 # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicate # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing1 # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing2 # Should have failed to parse, but didn't.
+Recommended.Proto2.JsonInput.FieldNameDuplicate # Should have failed to parse, but didn't.
+Recommended.Proto2.JsonInput.FieldNameDuplicateDifferentCasing1 # Should have failed to parse, but didn't.
+Recommended.Proto2.JsonInput.FieldNameDuplicateDifferentCasing2 # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicate # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing1 # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing2 # Should have failed to parse, but didn't.
+Required.Editions_Proto2.JsonInput.OneofFieldDuplicate # Should have failed to parse, but didn't.
+Required.Editions_Proto3.JsonInput.OneofFieldDuplicate # Should have failed to parse, but didn't.
+Required.Proto2.JsonInput.OneofFieldDuplicate # Should have failed to parse, but didn't.
+Required.Proto3.JsonInput.OneofFieldDuplicate # Should have failed to parse, but didn't.

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -640,8 +640,7 @@ def test_from_json_duplicate_list_field_replaces(first: str, second: str) -> Non
 
 
 @pytest.mark.parametrize(
-    ("first", "second"),
-    [("mapField", "mapField"), ("map_field", "mapField")],
+    ("first", "second"), [("mapField", "mapField"), ("map_field", "mapField")]
 )
 def test_from_json_duplicate_map_field_replaces(first: str, second: str) -> None:
     msg = MixedFields.from_json(f'{{"{first}": {{"x": 1}}, "{second}": {{"y": 2}}}}')

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -591,26 +591,23 @@ def test_from_json_map_error(
 
 
 def test_from_json_oneof_set_multiple_times() -> None:
-    with pytest.raises(ValueError, match="oneof set multiple times"):
-        MixedFields.from_json(json.dumps({"oneofField": "a", "oneofBaz": 1}))
+    msg = MixedFields.from_json(json.dumps({"oneofField": "a", "oneofBaz": 1}))
+    assert msg.oneof_group == Oneof(field="oneof_baz", value=1)
 
 
 def test_from_json_duplicate_key() -> None:
-    with pytest.raises(ValueError, match="duplicate key: scalarFieldJsonName"):
-        JsonNames.from_json('{"scalarFieldJsonName": 1, "scalarFieldJsonName": 2}')
+    msg = JsonNames.from_json('{"scalarFieldJsonName": 1, "scalarFieldJsonName": 2}')
+    assert msg.scalar_field == 2
 
 
 def test_from_json_field_set_multiple_times() -> None:
-    with pytest.raises(
-        ValueError,
-        match="field set multiple times by scalar_field and scalarFieldJsonName",
-    ):
-        JsonNames.from_json('{"scalar_field": 1, "scalarFieldJsonName": 2}')
+    msg = JsonNames.from_json('{"scalar_field": 1, "scalarFieldJsonName": 2}')
+    assert msg.scalar_field == 2
 
 
 def test_from_json_map_duplicate_key() -> None:
-    with pytest.raises(ValueError, match="duplicate key: a"):
-        Maps.from_json('{"stringToString": {"a": "1", "a": "2"}}')
+    msg = Maps.from_json('{"stringToString": {"a": "1", "a": "2"}}')
+    assert msg.string_to_string == {"a": "2"}
 
 
 def test_from_json_map_distinct_raw_keys_not_duplicate() -> None:
@@ -618,6 +615,37 @@ def test_from_json_map_distinct_raw_keys_not_duplicate() -> None:
     # same int32 map key but are distinct raw keys, so the last entry wins.
     msg = Maps.from_json('{"int32ToInt32": {"3": 1, "3.0": 2}}')
     assert msg.int32_to_int32 == {3: 2}
+
+
+# A duplicated field replaces the earlier value rather than merging into it.
+# The key pair is parametrized because identical keys are collapsed by
+# json.loads before the pure-Python parser runs, while the proto name and JSON
+# name of one field reach both parsers as two distinct keys.
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [("messageField", "messageField"), ("message_field", "messageField")],
+)
+def test_from_json_duplicate_message_field_replaces(first: str, second: str) -> None:
+    msg = MixedFields.from_json(f'{{"{first}": {{"value": "a"}}, "{second}": {{}}}}')
+    assert msg.message_field == MixedFields.Bar()
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [("repeatedField", "repeatedField"), ("repeated_field", "repeatedField")],
+)
+def test_from_json_duplicate_list_field_replaces(first: str, second: str) -> None:
+    msg = MixedFields.from_json(f'{{"{first}": ["a"], "{second}": ["b"]}}')
+    assert msg.repeated_field == ["b"]
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [("mapField", "mapField"), ("map_field", "mapField")],
+)
+def test_from_json_duplicate_map_field_replaces(first: str, second: str) -> None:
+    msg = MixedFields.from_json(f'{{"{first}": {{"x": 1}}, "{second}": {{"y": 2}}}}')
+    assert msg.map_field == {"y": 2}
 
 
 def _test_roundtrip(

--- a/tests/test_json_wkt.py
+++ b/tests/test_json_wkt.py
@@ -461,13 +461,17 @@ def test_struct_from_json_error(json_str: str) -> None:
         Struct.from_json(json_str)
 
 
-@pytest.mark.parametrize(
-    ("json_str", "key"),
-    [('{"a": 1, "a": 2}', "a"), ('{"outer": {"b": 1, "b": 2}}', "b")],
-)
-def test_struct_from_json_duplicate_key(json_str: str, key: str) -> None:
-    with pytest.raises(ValueError, match=f"duplicate key: {key}"):
-        Struct.from_json(json_str)
+def test_struct_from_json_duplicate_key() -> None:
+    msg = Struct.from_json('{"a": 1, "a": 2}')
+    assert msg.fields["a"] == Value(kind=Oneof(field="number_value", value=2))
+
+
+def test_struct_from_json_duplicate_key_inner() -> None:
+    msg = Struct.from_json('{"outer": {"b": 1, "b": 2}}')
+    assert msg.fields["outer"].kind == Oneof(
+        field="struct_value",
+        value=Struct(fields={"b": Value(kind=Oneof(field="number_value", value=2))}),
+    )
 
 
 @pytest.mark.parametrize("json_str", ['"abc"', '{"a": 1}'])


### PR DESCRIPTION
This proposes to still treat failures of JSON duplicates in conformance as "full conformance" since we know the tests have been fixed upstream, but the v37 release for that is quite a ways away. I don't feel that strongly about this and can wait, but curious what others think.

With the change, we beat pydantic across the board, flipped from losing across the board.

```
----------------------------------------------------------------------------------------- benchmark 'test_parse_json _id=buffa:log_record.pb:log_record:1': 2 tests -----------------------------------------------------------------------------------------
Name (time in ns)                                                          Min                     Max                  Mean                StdDev                Median                IQR              Outliers  OPS (Kops/s)            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_parse_json[bufbuild-rust-buffa:log_record.pb:log_record:1]       999.9785 (1.0)       66,042.0046 (1.0)      1,197.4575 (1.0)        738.4741 (1.0)      1,125.0086 (1.0)      42.0259 (1.0)      4538;11696      835.1027 (1.0)      190476           1
test_parse_json[pydantic-buffa:log_record.pb:log_record:1]          1,124.9795 (1.13)     337,957.9866 (5.12)     1,366.7446 (1.14)     2,528.8407 (3.42)     1,250.0095 (1.11)     42.0259 (1.0)        188;4922      731.6656 (0.88)      51613           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```