### PR TITLE
Implement eq in native

### DIFF
--- a/packages/bench/tests/test_bench.py
+++ b/packages/bench/tests/test_bench.py
@@ -391,6 +391,32 @@ class TestBench:
                 message.ParseFromString(payload)
                 benchmark(deepcopy, message)
 
+    @pytest.mark.parametrize(("_id", "typename", "payload"), all_external_cases)
+    def test_eq(
+        self,
+        _id: str,
+        typename: str,
+        payload: bytes,
+        impl: Impl,
+        registry: Registry,
+        benchmark: BenchmarkFixture,
+    ) -> None:
+        match impl:
+            case "bufbuild-python" | "bufbuild-rust":
+                message_desc = registry.message(typename)
+                assert message_desc is not None, (
+                    f"Message {typename} not found in registry"
+                )
+                message = message_desc.type().from_binary(payload)
+                other = message_desc.type().from_binary(payload)
+                benchmark(message.__eq__, other)
+            case "google-python" | "google-upb":
+                message = _get_google_protobuf_message_instance(typename, impl)
+                message.ParseFromString(payload)
+                other = _get_google_protobuf_message_instance(typename, impl)
+                other.ParseFromString(payload)
+                benchmark(message.__eq__, other)
+
     class TestAttrAccess:
         _scalar_cases: ClassVar[list] = [
             pytest.param(

--- a/packages/protobuf-py-ext/src/nativemessage.rs
+++ b/packages/protobuf-py-ext/src/nativemessage.rs
@@ -305,6 +305,37 @@ impl NativeMessage {
         Ok(new)
     }
 
+    fn __eq__(
+        slf: &Bound<'_, Self>,
+        py: Python<'_>,
+        other: &Bound<'_, NativeMessage>,
+    ) -> PyResult<bool> {
+        if !other.is_instance(&slf.get_type())? {
+            return Ok(false);
+        }
+        let marshaler = NativeMessage::get_marshaler(slf)?;
+
+        for member in &marshaler.members {
+            if let Some(field_number) = member.field_number {
+                let slf_present = slf.get().has_present_field(field_number);
+                let other_present = other.get().has_present_field(field_number);
+                if slf_present != other_present {
+                    return Ok(false);
+                }
+                if !slf_present {
+                    continue;
+                }
+            }
+            let slf_value = member.attr.get(py, slf)?;
+            let other_value = member.attr.get(py, &other)?;
+            if !slf_value.is(&other_value) && !slf_value.eq(&other_value)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
     fn _merge_from(
         slf: &Bound<'_, Self>,
         py: Python<'_>,

--- a/src/protobuf/_message.py
+++ b/src/protobuf/_message.py
@@ -559,8 +559,10 @@ class Message(Generic[FieldNamesT], metaclass=MessageMeta):  # noqa: PLW1641
 
         Extensions and unknown fields are not considered in the comparison.
         """
-        if not isinstance(other, type(self)):
+        if not isinstance(other, Message):
             return NotImplemented
+        if not isinstance(other, type(self)):
+            return False
         for field in self._desc.fields:
             self_set = field in self
             other_set = field in other

--- a/tests/test_message_eq.py
+++ b/tests/test_message_eq.py
@@ -100,6 +100,18 @@ def test_not_equal(
     assert b != a
 
 
+def test_different_types() -> None:
+    a = MixedFields()
+    b = Scalars()
+    assert a != b
+    assert a.__eq__(b) is False
+    assert b != a
+    assert b.__eq__(a) is False
+
+    assert a.__eq__("hello") is NotImplemented
+    assert b.__eq__(42) is NotImplemented
+
+
 def test_eq_unknown_fields_ignored() -> None:
     a = MixedFields(explicit_field=1)
     b = MixedFields(explicit_field=1)


### PR DESCRIPTION
While not commonly a hot path function like marshaling is, it can still be used in some cases, and notably can be so commonly used in tests that we can make the world a little greener by optimizing it, especially given how small and simple the code is (<30 lines) while being high impact loops / native attr access. Notably, we're getting a lot out of being Python-native here, there is basically no reason to even examine field types here since letting Python do it is if not optimal close enough and probably why we win over upb here (pleasant surprise for me).

(
After
```
----------------------------------------------------------------------------------------- benchmark 'test_eq _id=buffa:log_record.pb:log_record:0': 4 tests ------------------------------------------------------------------------------------------
Name (time in ns)                                                    Min                     Max                  Mean                StdDev                Median                 IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_eq[bufbuild-rust-buffa:log_record.pb:log_record:0]         107.0800 (1.0)       76,528.3400 (1.17)       140.5951 (1.0)        428.4140 (1.29)       115.4095 (1.0)        4.1700 (1.0)      503;9304    7,112.6228 (1.0)       83043         100
test_eq[google-upb-buffa:log_record.pb:log_record:0]            162.5001 (1.52)      65,572.0901 (1.0)        182.9122 (1.30)       331.9590 (1.0)        173.3296 (1.50)       5.8301 (1.40)     136;2740    5,467.1038 (0.77)      54921         100
test_eq[google-python-buffa:log_record.pb:log_record:0]       2,167.0130 (20.24)    371,917.0345 (5.67)     2,410.5350 (17.15)    1,717.2397 (5.17)     2,374.9890 (20.58)     82.9459 (19.89)    322;2147      414.8457 (0.06)      76191           1
test_eq[bufbuild-python-buffa:log_record.pb:log_record:0]     7,291.9647 (68.10)     77,874.9818 (1.19)     8,236.6765 (58.58)    3,233.4488 (9.74)     7,750.0008 (67.15)    249.9437 (59.94)    505;1790      121.4082 (0.02)      20531           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Before
```
------------------------------------------------------------------------------------------- benchmark 'test_eq _id=buffa:log_record.pb:log_record:0': 4 tests -------------------------------------------------------------------------------------------
Name (time in ns)                                                    Min                     Max                   Mean                StdDev                Median                   IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_eq[google-upb-buffa:log_record.pb:log_record:0]            160.4494 (1.0)       52,470.8477 (1.0)         262.9462 (1.0)        284.4275 (1.0)        181.2499 (1.0)        156.2497 (1.0)     1721;1692    3,803.0592 (1.0)      150943          20
test_eq[google-python-buffa:log_record.pb:log_record:0]       2,249.9589 (14.02)    540,582.9870 (10.30)     4,343.0937 (16.52)    7,893.3173 (27.75)    2,457.9931 (13.56)    3,624.9985 (23.20)    952;1020      230.2506 (0.06)      57007           1
test_eq[bufbuild-rust-buffa:log_record.pb:log_record:0]       7,375.0271 (45.96)    258,916.9890 (4.93)     10,924.7203 (41.55)    8,165.2675 (28.71)    8,000.0027 (44.14)      498.9561 (3.19)     519;2804       91.5355 (0.02)      12202           1
test_eq[bufbuild-python-buffa:log_record.pb:log_record:0]     7,415.9470 (46.22)    325,416.9715 (6.20)     11,221.1349 (42.67)    7,713.9690 (27.12)    7,958.9663 (43.91)    9,749.9578 (62.40)     753;201       89.1175 (0.02)      17058           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```