### PR TITLE
Accept any buffer for from_binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
           - python-version: ${{ github.event_name == 'pull_request' && '3.15t' }}
     env:
       # When bumping, also bump top-level env in release.yaml
-      MATURIN_ARGS: ${{ (matrix.python-version == '3.10' || matrix.python-version == '3.11') && '--features pyo3/abi3-py310' || '' }}
+      MATURIN_ARGS: ${{ matrix.python-version == '3.11' && '--features pyo3/abi3-py311' || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv with Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,9 @@ permissions:
 env:
   # When bumping, also bump MATURIN_ARGS in ci.yaml
   # maturin flags to build targets we publish non-abi3 wheels for
-  UNSTABLE_API_FLAGS: -i 3.12 -i 3.13 -i 3.14 -i 3.14t
+  UNSTABLE_API_FLAGS: -i 3.10 -i 3.12 -i 3.13 -i 3.14 -i 3.14t
   # maturin flags to build targets we publish abi3 wheels for
-  ABI3_FLAGS: -i 3.10 --features pyo3/abi3-py310
+  ABI3_FLAGS: -i 3.11 --features pyo3/abi3-py311
 
 jobs:
   ext-linux:

--- a/packages/protobuf-py-ext/src/buffer.rs
+++ b/packages/protobuf-py-ext/src/buffer.rs
@@ -1,0 +1,37 @@
+use bytes::Bytes;
+use pyo3::buffer::PyBuffer;
+use pyo3::exceptions::PyBufferError;
+use pyo3::{Borrowed, FromPyObject, PyAny, PyErr, PyResult};
+
+// Wrapper to pass to from_owner satisfying the orphan rule.
+struct BufferOwner(PyBuffer<u8>);
+
+impl AsRef<[u8]> for BufferOwner {
+    fn as_ref(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.0.buf_ptr() as *const u8, self.0.len_bytes()) }
+    }
+}
+
+/// A Bytes view of a Python buffer protocol object.
+pub(crate) struct Buffer(Bytes);
+
+impl Buffer {
+    pub(crate) fn into_inner(self) -> Bytes {
+        self.0
+    }
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for Buffer {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+        if let Ok(bytes) = obj.extract::<Bytes>() {
+            return Ok(Buffer(bytes));
+        }
+        let buffer = PyBuffer::<u8>::get(&obj)?;
+        if !buffer.is_c_contiguous() {
+            return Err(PyBufferError::new_err("buffer is not contiguous"));
+        }
+        Ok(Buffer(Bytes::from_owner(BufferOwner(buffer))))
+    }
+}

--- a/packages/protobuf-py-ext/src/lib.rs
+++ b/packages/protobuf-py-ext/src/lib.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 mod alloc;
 mod attribute_access;
 mod bitset;
+mod buffer;
 mod constants;
 mod descriptor;
 mod json_parse;

--- a/packages/protobuf-py-ext/src/nativemessage.rs
+++ b/packages/protobuf-py-ext/src/nativemessage.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use pyo3::{
     Bound, IntoPyObject as _, IntoPyObjectExt as _, Py, PyAny, PyResult, Python,
     exceptions::PyTypeError,
@@ -14,6 +13,7 @@ use pyo3::{
 use crate::{
     attribute_access::generic_setattr,
     bitset::BitSet,
+    buffer::Buffer,
     constants::Constants,
     json_parse::{FromJsonOpts, merge_from_json, read_message_from_tree},
     json_serialize::JsonOpts,
@@ -104,9 +104,10 @@ impl NativeMessage {
     fn from_binary<'py>(
         cls: &Bound<'py, PyType>,
         py: Python<'py>,
-        data: Bytes,
+        data: Buffer,
         ignore_unknown_fields: bool,
     ) -> PyResult<Bound<'py, NativeMessage>> {
+        let data = data.into_inner();
         let constants = Constants::get(py)?;
         let marshaler_any = cls.getattr(&constants.ext_marshaler)?;
         let marshaler = marshaler_any.cast::<MessageMarshaler>()?.get();
@@ -266,9 +267,10 @@ impl NativeMessage {
     fn _merge_from_binary(
         slf: &Bound<'_, Self>,
         py: Python<'_>,
-        data: Bytes,
+        data: Buffer,
         ignore_unknown_fields: bool,
     ) -> PyResult<()> {
+        let data = data.into_inner();
         NativeMessage::get_marshaler(slf)?.merge_from_binary(py, slf, data, ignore_unknown_fields)
     }
 

--- a/src/protobuf/_from_binary.py
+++ b/src/protobuf/_from_binary.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from typing_extensions import assert_never
+from typing_extensions import Buffer, assert_never
 
 from ._descriptors import (
     DescEnum,
@@ -367,7 +367,7 @@ def _read_unknown_map_entry(
 
 
 def merge_from_binary(
-    message: Message, data: bytes, *, ignore_unknown_fields: bool = False
+    message: Message, data: Buffer, *, ignore_unknown_fields: bool = False
 ) -> None:
     """Parse serialized binary data, merging fields into an existing message.
 
@@ -381,7 +381,7 @@ def merge_from_binary(
 
     Args:
         message: The message instance to merge into.
-        data: Serialized binary protobuf data.
+        data: Serialized binary protobuf data. Must not be mutated during parsing.
         ignore_unknown_fields: If `True`, unknown fields in the binary data are silently discarded.
     """
     message._merge_from_binary(data, ignore_unknown_fields)

--- a/src/protobuf/_message.py
+++ b/src/protobuf/_message.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from copy import copy, deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, overload
 
-from typing_extensions import TypeVar
+from typing_extensions import Buffer, TypeVar
 
 from . import _native_message
 from ._descriptors import (
@@ -611,14 +611,14 @@ class Message(Generic[FieldNamesT], metaclass=MessageMeta):  # noqa: PLW1641
 
     @classmethod
     def from_binary(
-        cls: type[Self], data: bytes, *, ignore_unknown_fields: bool = False
+        cls: type[Self], data: Buffer, *, ignore_unknown_fields: bool = False
     ) -> Self:
         """Create a new message by parsing serialized binary data.
 
         To merge into an existing message, use [`merge_from_binary`][].
 
         Args:
-            data: Serialized binary protobuf data.
+            data: Serialized binary protobuf data. Must not be mutated during parsing.
             ignore_unknown_fields: If `True`, unknown fields in the binary data are silently discarded.
         """
         message = cls()
@@ -671,11 +671,10 @@ class Message(Generic[FieldNamesT], metaclass=MessageMeta):  # noqa: PLW1641
 
     # Marshaling methods overridden in native code when available.
 
-    def _merge_from_binary(self, data: bytes, ignore_unknown_fields: bool) -> None:  # noqa: FBT001
+    def _merge_from_binary(self, data: Buffer, ignore_unknown_fields: bool) -> None:  # noqa: FBT001
         opts = FromBinaryOptions(ignore_unknown_fields=ignore_unknown_fields)
-        read_message(
-            self, BinaryReader(memoryview(data)), opts, depth=0, length=len(data)
-        )
+        view = memoryview(data)
+        read_message(self, BinaryReader(view), opts, depth=0, length=len(view))
 
     def _merge_from_json(
         self,

--- a/tests/test_from_binary.py
+++ b/tests/test_from_binary.py
@@ -26,6 +26,7 @@ from protobuf import (
     DescMessage,
     Message,
     ScalarType,
+    merge_from_binary,
 )
 from protobuf._wire import BinaryWriter, WireType
 
@@ -38,6 +39,25 @@ from .gen.scalars_pb import Scalars
 
 if TYPE_CHECKING:
     from .conftest import Protoc
+
+
+MSG_BYTES = Scalars(int32_field=1).to_binary()
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        pytest.param(MSG_BYTES, id="bytes"),
+        pytest.param(bytearray(MSG_BYTES), id="bytearray"),
+        pytest.param(memoryview(MSG_BYTES), id="memoryview"),
+    ],
+)
+def test_from_binary_buffer(obj: bytes | bytearray | memoryview) -> None:
+    msg = Scalars.from_binary(obj)
+    assert msg.int32_field == 1
+    msg = Scalars()
+    merge_from_binary(msg, obj)
+    assert msg.int32_field == 1
 
 
 def encode_map_entry(desc_field: DescField, *, key: Any, value: Any) -> bytes:


### PR DESCRIPTION
Actually we were already passing `bytearray` from connect-py and ty wasn't able to catch the miss until a recent version

https://github.com/connectrpc/connect-py/pull/324/changes#diff-f5bd8b32a6a1e78a29b79f0c2cd4a743338c0b31810f737bcc63cd20c7cd4dd1L75

This formalizes accepting any contiguous buffer protocol object, conveniently taking advantage of the recent introduction of typing_extensions for it. Pure python already supported it by wrapping in `memoryview`, this also adds buffer extraction for native.

This also goes ahead and bumps our stable ABI target to 3.11, needed for buffer protocol - we continue to support 3.10 by publishing a version-specific wheel for it so there is no real UX change from it. That will stop end of October when it is EoL.