### PR TITLE
Add depth limit to serialization

### DIFF
--- a/packages/protobuf-py-ext/src/json_serialize.rs
+++ b/packages/protobuf-py-ext/src/json_serialize.rs
@@ -17,7 +17,10 @@ use crate::{
     json_sink::{JsonSink, StringSink},
     marshaler::MessageMarshaler,
     nativemessage::NativeMessage,
-    serializer::{FieldSerializer, FieldSerializerType, FieldSerializerValue, MessageSerializer},
+    serializer::{
+        FieldSerializer, FieldSerializerType, FieldSerializerValue, MessageSerializer,
+        check_serialize_recursion_depth,
+    },
 };
 
 const INT32_MIN: i64 = -(1 << 31);
@@ -42,7 +45,7 @@ impl MessageMarshaler {
         opts: &JsonOpts,
     ) -> PyResult<Py<PyString>> {
         let mut sink = StringSink::new();
-        self.write_json(py, message, &mut sink, opts)?;
+        self.write_json(py, message, &mut sink, opts, 0)?;
         Ok(PyString::new(py, &sink.finish()).unbind())
     }
 
@@ -53,10 +56,12 @@ impl MessageMarshaler {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
+        check_serialize_recursion_depth(depth)?;
         match &self.wkt {
-            Some(wkt) => wkt.write_json(self, py, message, sink, opts),
-            None => self.write_message_object(py, message, sink, opts),
+            Some(wkt) => wkt.write_json(self, py, message, sink, opts, depth),
+            None => self.write_message_object(py, message, sink, opts, depth),
         }
     }
 
@@ -67,9 +72,10 @@ impl MessageMarshaler {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         sink.begin_object()?;
-        self.write_message_fields(py, message, sink, opts)?;
+        self.write_message_fields(py, message, sink, opts, depth)?;
         sink.end_object()?;
         Ok(())
     }
@@ -82,6 +88,7 @@ impl MessageMarshaler {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         self.serializer.validate_oneofs(py, message.as_any())?;
         for field in self.serializer.fields() {
@@ -96,11 +103,13 @@ impl MessageMarshaler {
                 field.json_name.bind(py)
             };
             sink.py_key(key)?;
-            field.serializer.write_json_value(py, &value, sink, opts)?;
+            field
+                .serializer
+                .write_json_value(py, &value, sink, opts, depth)?;
         }
         if let Some(registry) = &opts.registry {
             let registry = registry.bind(py);
-            self.write_extensions(py, message, sink, opts, registry)?;
+            self.write_extensions(py, message, sink, opts, registry, depth)?;
         }
         Ok(())
     }
@@ -112,6 +121,7 @@ impl MessageMarshaler {
         sink: &mut S,
         opts: &JsonOpts,
         registry: &Bound<'_, PyAny>,
+        depth: usize,
     ) -> PyResult<()> {
         let Some(unknown_fields) = message.get().unknown_fields(py) else {
             return Ok(());
@@ -136,7 +146,7 @@ impl MessageMarshaler {
             let type_name = ext_desc.getattr(&self.constants.type_name)?;
             let type_name = type_name.extract::<&str>()?;
             sink.key(&format!("[{type_name}]"))?;
-            write_desc_field_value(py, &field_value, &value, sink, opts)?;
+            write_desc_field_value(py, &field_value, &value, sink, opts, depth)?;
         }
         Ok(())
     }
@@ -150,14 +160,17 @@ impl FieldSerializer {
         value: &Bound<'_, PyAny>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         match &self.type_ {
-            FieldSerializerType::Singular => self.write_single_json_value(py, value, sink, opts),
+            FieldSerializerType::Singular => {
+                self.write_single_json_value(py, value, sink, opts, depth)
+            }
             FieldSerializerType::List { .. } => {
                 let list = value.cast::<PyList>()?;
                 sink.begin_array()?;
                 for item in list {
-                    self.write_single_json_value(py, &item, sink, opts)?;
+                    self.write_single_json_value(py, &item, sink, opts, depth)?;
                 }
                 sink.end_array()?;
                 Ok(())
@@ -173,7 +186,7 @@ impl FieldSerializer {
                 sink.begin_object()?;
                 for (key, val) in dict {
                     write_map_key(*key_type, &key, sink)?;
-                    value_serializer.write_single_json_value(py, &val, sink, opts)?;
+                    value_serializer.write_single_json_value(py, &val, sink, opts, depth)?;
                 }
                 sink.end_object()?;
                 Ok(())
@@ -188,12 +201,13 @@ impl FieldSerializer {
         value: &Bound<'_, PyAny>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         match &self.value {
             FieldSerializerValue::Scalar(scalar) => write_scalar_json(*scalar, value, sink),
             FieldSerializerValue::Enum(enum_) => write_enum_json(py, enum_, value, sink, opts),
             FieldSerializerValue::Message { message, .. } => {
-                write_message_json(py, message, value, sink, opts)
+                write_message_json(py, message, value, sink, opts, depth)
             }
         }
     }
@@ -207,18 +221,19 @@ fn write_desc_field_value<S: JsonSink>(
     value: &Bound<'_, PyAny>,
     sink: &mut S,
     opts: &JsonOpts,
+    depth: usize,
 ) -> PyResult<()> {
     match field_value {
         DescFieldValue::Scalar { scalar_type, .. } => write_scalar_json(*scalar_type, value, sink),
         DescFieldValue::Enum { enum_, .. } => write_enum_json(py, enum_, value, sink, opts),
         DescFieldValue::Message { message, .. } => {
-            write_message_json(py, message, value, sink, opts)
+            write_message_json(py, message, value, sink, opts, depth)
         }
         DescFieldValue::List { element, .. } => {
             let list = value.cast::<PyList>()?;
             sink.begin_array()?;
             for item in list.iter() {
-                write_single_desc_value(py, element, &item, sink, opts)?;
+                write_single_desc_value(py, element, &item, sink, opts, depth)?;
             }
             sink.end_array()?;
             Ok(())
@@ -235,12 +250,13 @@ fn write_single_desc_value<S: JsonSink>(
     value: &Bound<'_, PyAny>,
     sink: &mut S,
     opts: &JsonOpts,
+    depth: usize,
 ) -> PyResult<()> {
     match element {
         DescSingleValue::Scalar(scalar) => write_scalar_json(*scalar, value, sink),
         DescSingleValue::Enum(enum_) => write_enum_json(py, enum_, value, sink, opts),
         DescSingleValue::Message { message, .. } => {
-            write_message_json(py, message, value, sink, opts)
+            write_message_json(py, message, value, sink, opts, depth)
         }
     }
 }
@@ -276,6 +292,7 @@ pub(crate) fn write_message_json<S: JsonSink>(
     value: &Bound<'_, PyAny>,
     sink: &mut S,
     opts: &JsonOpts,
+    depth: usize,
 ) -> PyResult<()> {
     let expected_type = message_desc.get_python_type(py);
     if !value.is_instance(expected_type)? {
@@ -287,7 +304,7 @@ pub(crate) fn write_message_json<S: JsonSink>(
     }
     let value = value.cast::<NativeMessage>()?;
     let marshaler = NativeMessage::get_marshaler(value)?;
-    marshaler.write_json(py, value, sink, opts)
+    marshaler.write_json(py, value, sink, opts, depth + 1)
 }
 
 fn write_enum_json<S: JsonSink>(

--- a/packages/protobuf-py-ext/src/marshaler.rs
+++ b/packages/protobuf-py-ext/src/marshaler.rs
@@ -248,6 +248,7 @@ impl MessageMarshaler {
             &mut buffer,
             ToBinaryOpts {
                 write_unknown_fields,
+                depth: 0,
             },
         )?;
         Ok(buffer.into_py_bytes(py))

--- a/packages/protobuf-py-ext/src/nativemessage.rs
+++ b/packages/protobuf-py-ext/src/nativemessage.rs
@@ -198,7 +198,7 @@ impl NativeMessage {
             registry,
         };
         let mut sink = PyValueSink::new(py);
-        marshaler.write_json(py, slf, &mut sink, &opts)?;
+        marshaler.write_json(py, slf, &mut sink, &opts, 0)?;
         sink.finish()
     }
 
@@ -329,7 +329,7 @@ impl NativeMessage {
                 }
             }
             let slf_value = member.attr.get(py, slf)?;
-            let other_value = member.attr.get(py, &other)?;
+            let other_value = member.attr.get(py, other)?;
             if !slf_value.is(&other_value) && !slf_value.eq(&other_value)? {
                 return Ok(false);
             }

--- a/packages/protobuf-py-ext/src/serializer.rs
+++ b/packages/protobuf-py-ext/src/serializer.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use pyo3::{
     Bound, Py, PyAny, PyErr, PyResult, Python,
-    exceptions::{PyOverflowError, PyTypeError, PyValueError},
+    exceptions::{PyOverflowError, PyRecursionError, PyTypeError, PyValueError},
     types::{
         PyAnyMethods as _, PyBool, PyBytes, PyBytesMethods as _, PyDict, PyDictMethods as _, PyInt,
         PyList, PyListMethods as _, PyString, PyStringMethods as _, PyType,
@@ -31,10 +31,24 @@ use crate::{
     reverse_buffer::ReverseBuffer,
 };
 
+const DEPTH_LIMIT: usize = 100;
+
 #[derive(Clone, Copy)]
 pub(crate) struct ToBinaryOpts {
     /// Whether to include unknown fields when writing wire bytes.
     pub(crate) write_unknown_fields: bool,
+    /// Current message nesting depth.
+    pub(crate) depth: usize,
+}
+
+/// Raises if serializing a nested message exceeds the shared recursion limit.
+pub(crate) fn check_serialize_recursion_depth(depth: usize) -> PyResult<()> {
+    if depth > DEPTH_LIMIT {
+        return Err(PyRecursionError::new_err(format!(
+            "exceeded maximum recursion depth {DEPTH_LIMIT} while serializing message"
+        )));
+    }
+    Ok(())
 }
 
 /// Per-field serialization mode and container-specific state.
@@ -579,6 +593,12 @@ impl MessageSerializer {
         buffer: &mut ReverseBuffer,
         opts: ToBinaryOpts,
     ) -> PyResult<()> {
+        check_serialize_recursion_depth(opts.depth)?;
+        let opts = ToBinaryOpts {
+            depth: opts.depth + 1,
+            ..opts
+        };
+
         if !message.is_instance(self.inner.python_type.bind(py))? {
             return Err(PyTypeError::new_err(format!(
                 "expected {}, got '{}'",

--- a/packages/protobuf-py-ext/src/wkt_registry.rs
+++ b/packages/protobuf-py-ext/src/wkt_registry.rs
@@ -44,6 +44,7 @@ impl WktTimestamp {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         _opts: &JsonOpts,
+        _depth: usize,
     ) -> PyResult<()> {
         let secs = read_int64_attr(py, message, &self.seconds)?;
         let nanos = read_int32_attr(py, message, &self.nanos)?;
@@ -84,6 +85,7 @@ impl WktDuration {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         _opts: &JsonOpts,
+        _depth: usize,
     ) -> PyResult<()> {
         let secs = read_int64_attr(py, message, &self.seconds)?;
         let nanos = read_int32_attr(py, message, &self.nanos)?;
@@ -124,6 +126,7 @@ impl WktAny {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         let constants = &marshaler.constants;
         let type_url_py = self.type_url.get(py, message.as_any())?;
@@ -161,13 +164,13 @@ impl WktAny {
             // Regular message: inline its fields after `@type`.
             sink.key("@type")?;
             sink.str(type_url)?;
-            inner_marshaler.write_message_fields(py, &inner_msg, sink, opts)?;
+            inner_marshaler.write_message_fields(py, &inner_msg, sink, opts, depth + 1)?;
         } else {
             // Well-known type with a custom JSON representation: wrap in `value`.
             sink.key("@type")?;
             sink.str(type_url)?;
             sink.key("value")?;
-            inner_marshaler.write_json(py, &inner_msg, sink, opts)?;
+            inner_marshaler.write_json(py, &inner_msg, sink, opts, depth + 1)?;
         }
         sink.end_object()?;
         Ok(())
@@ -266,6 +269,7 @@ impl WktFieldMask {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         _opts: &JsonOpts,
+        _depth: usize,
     ) -> PyResult<()> {
         let paths = self
             .paths
@@ -334,6 +338,7 @@ impl WktStruct {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         let map = self
             .fields
@@ -342,7 +347,7 @@ impl WktStruct {
         sink.begin_object()?;
         for (key, entry) in map {
             sink.py_key(key.cast::<PyString>()?)?;
-            write_message_json(py, &self.value, &entry, sink, opts)?;
+            write_message_json(py, &self.value, &entry, sink, opts, depth)?;
         }
         sink.end_object()?;
         Ok(())
@@ -396,6 +401,7 @@ impl WktListValue {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         let values = self
             .values
@@ -403,7 +409,7 @@ impl WktListValue {
             .cast_into::<PyList>()?;
         sink.begin_array()?;
         for item in values.iter() {
-            write_message_json(py, &self.element, &item, sink, opts)?;
+            write_message_json(py, &self.element, &item, sink, opts, depth)?;
         }
         sink.end_array()?;
         Ok(())
@@ -464,6 +470,7 @@ impl WktValue {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         let Ok(oneof) = self.kind.get(py, message.as_any())?.cast_into::<Oneof>() else {
             return Err(PyValueError::new_err(
@@ -484,8 +491,12 @@ impl WktValue {
             }
             "string_value" => sink.py_str(kind_value.cast::<PyString>()?),
             "bool_value" => sink.bool(kind_value.extract::<bool>()?),
-            "struct_value" => write_message_json(py, &self.struct_message, kind_value, sink, opts),
-            "list_value" => write_message_json(py, &self.list_message, kind_value, sink, opts),
+            "struct_value" => {
+                write_message_json(py, &self.struct_message, kind_value, sink, opts, depth)
+            }
+            "list_value" => {
+                write_message_json(py, &self.list_message, kind_value, sink, opts, depth)
+            }
             _ => Err(PyValueError::new_err(
                 "value must have exactly one field set",
             )),
@@ -557,6 +568,7 @@ impl WktWrapper {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         _opts: &JsonOpts,
+        _depth: usize,
     ) -> PyResult<()> {
         let value = self.field.get(py, message.as_any())?;
         write_scalar_json(self.scalar, &value, sink)
@@ -605,16 +617,17 @@ impl WktKind {
         message: &Bound<'_, NativeMessage>,
         sink: &mut S,
         opts: &JsonOpts,
+        depth: usize,
     ) -> PyResult<()> {
         match self {
-            WktKind::Timestamp(w) => w.write_json(marshaler, py, message, sink, opts),
-            WktKind::Duration(w) => w.write_json(marshaler, py, message, sink, opts),
-            WktKind::Any(w) => w.write_json(marshaler, py, message, sink, opts),
-            WktKind::FieldMask(w) => w.write_json(marshaler, py, message, sink, opts),
-            WktKind::Struct(w) => w.write_json(marshaler, py, message, sink, opts),
-            WktKind::ListValue(w) => w.write_json(marshaler, py, message, sink, opts),
-            WktKind::Value(w) => w.write_json(marshaler, py, message, sink, opts),
-            WktKind::Wrapper(w) => w.write_json(marshaler, py, message, sink, opts),
+            WktKind::Timestamp(w) => w.write_json(marshaler, py, message, sink, opts, depth),
+            WktKind::Duration(w) => w.write_json(marshaler, py, message, sink, opts, depth),
+            WktKind::Any(w) => w.write_json(marshaler, py, message, sink, opts, depth),
+            WktKind::FieldMask(w) => w.write_json(marshaler, py, message, sink, opts, depth),
+            WktKind::Struct(w) => w.write_json(marshaler, py, message, sink, opts, depth),
+            WktKind::ListValue(w) => w.write_json(marshaler, py, message, sink, opts, depth),
+            WktKind::Value(w) => w.write_json(marshaler, py, message, sink, opts, depth),
+            WktKind::Wrapper(w) => w.write_json(marshaler, py, message, sink, opts, depth),
         }
     }
 

--- a/src/protobuf/_unknown.py
+++ b/src/protobuf/_unknown.py
@@ -43,6 +43,7 @@ from ._to_binary import (
     write_message_field,
     write_scalar_field,
 )
+from ._validate import validate_field_value
 from ._wire import BinaryReader, BinaryWriter
 
 if TYPE_CHECKING:
@@ -134,6 +135,8 @@ def get_unknown_field(
 def set_unknown_field(
     message: Message, number: int, field_value: DescFieldValue, value: Any
 ) -> None:
+    # The writers assume validated input, so validate here like to_binary does.
+    validate_field_value(field_value, value)
     writer = BinaryWriter()
     match field_value:
         case DescFieldValueScalar():

--- a/src/protobuf/_validate.py
+++ b/src/protobuf/_validate.py
@@ -21,6 +21,7 @@ from typing_extensions import assert_never
 from ._descriptors import (
     DescEnum,
     DescField,
+    DescFieldValue,
     DescFieldValueEnum,
     DescFieldValueList,
     DescFieldValueMap,
@@ -32,6 +33,7 @@ from ._descriptors import (
     SupportedFieldPresence,
 )
 from ._oneof import Oneof
+from ._wire._binary_reader import DEPTH_LIMIT
 
 if TYPE_CHECKING:
     from ._message import Message
@@ -49,7 +51,7 @@ FLOAT32_MAX = 3.4028234663852886e38
 FLOAT32_MIN = -3.4028234663852886e38
 
 
-def validate(message: Message, /) -> None:
+def validate(message: Message, /, depth: int = 0) -> None:
     """Validate a message for correctness before serialization.
 
     Checks that all field values have the correct types and that
@@ -57,18 +59,25 @@ def validate(message: Message, /) -> None:
 
     Args:
         message: The message to validate.
+        depth: Current message nesting depth.
 
     Raises:
         TypeError: If a field value has the wrong type.
         OverflowError: If a numeric value is out of range.
         ValueError: If an enum or oneof field has an invalid value.
+        RecursionError: If message nesting exceeds the recursion limit.
     """
+    if depth > DEPTH_LIMIT:
+        msg = (
+            f"exceeded maximum recursion depth {DEPTH_LIMIT} while serializing message"
+        )
+        raise RecursionError(msg)
     # Iterate over members instead of fields to validate oneofs instead of
     # silently skipping them.
     for member in message._desc.members:
         if isinstance(member, DescOneof):
             if (value := getattr(message, member.local_name)) is not None:
-                _validate_oneof(member, value)
+                _validate_oneof(member, value, depth)
             continue
         if not message._contains_member(member):
             if member.presence == SupportedFieldPresence.LEGACY_REQUIRED:
@@ -78,33 +87,44 @@ def validate(message: Message, /) -> None:
         value: object = message._get_member(member)
         match member:
             case DescField():
-                match field_value := member.value:
-                    case DescFieldValueScalar():
-                        _validate_scalar_type(field_value.scalar, value)
-                    case DescFieldValueMessage():
-                        _validate_message_value(field_value.message, value)
-                    case DescFieldValueEnum():
-                        _validate_enum(field_value.enum, value)
-                    case DescFieldValueList():
-                        if not isinstance(value, list):
-                            msg = f"expected list, got {type(value)}"
-                            raise TypeError(msg)
-                        for element in value:
-                            _validate_container_element(field_value.element, element)
-                    case DescFieldValueMap():
-                        if not isinstance(value, dict):
-                            msg = f"expected dict, got {type(value)}"
-                            raise TypeError(msg)
-                        for k, v in value.items():
-                            _validate_scalar_type(field_value.key, k)
-                            _validate_container_element(field_value.value, v)
-                    case _:
-                        assert_never(field_value)
+                validate_field_value(member.value, value, depth)
             case _:
                 assert_never(member)
 
 
-def _validate_oneof(desc: DescOneof, value: object) -> None:
+def validate_field_value(
+    field_value: DescFieldValue, value: object, depth: int = 0
+) -> None:
+    """Validate a single field value for correctness before serialization.
+
+    Used both for message fields and for values serialized outside a
+    validated message, such as extension values.
+    """
+    match field_value:
+        case DescFieldValueScalar():
+            _validate_scalar_type(field_value.scalar, value)
+        case DescFieldValueMessage():
+            _validate_message_value(field_value.message, value, depth)
+        case DescFieldValueEnum():
+            _validate_enum(field_value.enum, value)
+        case DescFieldValueList():
+            if not isinstance(value, list):
+                msg = f"expected list, got {type(value)}"
+                raise TypeError(msg)
+            for element in value:
+                _validate_container_element(field_value.element, element, depth)
+        case DescFieldValueMap():
+            if not isinstance(value, dict):
+                msg = f"expected dict, got {type(value)}"
+                raise TypeError(msg)
+            for k, v in value.items():
+                _validate_scalar_type(field_value.key, k)
+                _validate_container_element(field_value.value, v, depth)
+        case _:
+            assert_never(field_value)
+
+
+def _validate_oneof(desc: DescOneof, value: object, depth: int) -> None:
     if not isinstance(value, Oneof):
         msg = f"{desc.parent.type_name}.{desc.name}: expected Oneof, got {type(value)}"
         raise TypeError(msg)
@@ -119,7 +139,7 @@ def _validate_oneof(desc: DescOneof, value: object) -> None:
         case DescFieldValueScalar(scalar=scalar):
             _validate_scalar_type(scalar, value)
         case DescFieldValueMessage(message=message):
-            _validate_message_value(message, value)
+            _validate_message_value(message, value, depth)
         case DescFieldValueEnum(enum=enum):
             _validate_enum(enum, value)
         case _:
@@ -128,7 +148,7 @@ def _validate_oneof(desc: DescOneof, value: object) -> None:
 
 
 def _validate_container_element(
-    element_type: ScalarType | DescEnum | DescMessage, value: object
+    element_type: ScalarType | DescEnum | DescMessage, value: object, depth: int
 ) -> None:
     match element_type:
         case ScalarType():
@@ -136,12 +156,12 @@ def _validate_container_element(
         case DescEnum():
             _validate_enum(element_type, value)
         case DescMessage():
-            _validate_message_value(element_type, value)
+            _validate_message_value(element_type, value, depth)
         case _:
             assert_never(element_type)
 
 
-def _validate_message_value(desc: DescMessage, value: object) -> None:
+def _validate_message_value(desc: DescMessage, value: object, depth: int) -> None:
     from ._message import Message  # noqa: PLC0415
 
     if not isinstance(value, Message):
@@ -150,7 +170,7 @@ def _validate_message_value(desc: DescMessage, value: object) -> None:
     if value._desc.type_name != desc.type_name:
         msg = f"expected {desc.type_name!r}, got {value._desc.type_name!r}"
         raise TypeError(msg)
-    validate(value)
+    validate(value, depth + 1)
 
 
 def _validate_enum(desc: DescEnum, value: object) -> None:

--- a/tests/test_extensions_proto2.py
+++ b/tests/test_extensions_proto2.py
@@ -277,3 +277,9 @@ def test_closed_repeated_enum_known_and_unknown_values() -> None:
     msg = Proto2Extendee.from_binary(data)
     assert ext_repeated_enum_ext in msg
     assert msg[ext_repeated_enum_ext] == [Proto2ExtEnum.NO]
+
+
+def test_set_extension_wrong_message_type() -> None:
+    msg = Proto2Extendee()
+    with pytest.raises(TypeError, match=r"expected 'proto2ext\.Proto2ExtMessage'"):
+        msg[ext_message_ext] = cast("Any", User())

--- a/tests/test_from_binary.py
+++ b/tests/test_from_binary.py
@@ -38,6 +38,8 @@ from .gen.messages_pb import Recursive
 from .gen.scalars_pb import Scalars
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .conftest import Protoc
 
 
@@ -219,26 +221,45 @@ def test_equals_recursion_limit() -> None:
     assert msg == msg2
 
 
+def _wrap_length_delimited(field_number: int, payload: bytes) -> bytes:
+    w = BinaryWriter()
+    w.tag(field_number, WireType.LENGTH_DELIMITED)
+    w.fork()
+    w.raw(payload)
+    w.join()
+    return w.finish()
+
+
+def _wrap_map_entry(payload: bytes) -> bytes:
+    w = BinaryWriter()
+    w.tag(1, WireType.LENGTH_DELIMITED)
+    w.string("a")
+    w.tag(2, WireType.LENGTH_DELIMITED)
+    w.fork()
+    w.raw(payload)
+    w.join()
+    return w.finish()
+
+
 @pytest.mark.parametrize(
-    "msg",
+    "wrap_field",
     [
         pytest.param(
-            Recursive(recursive=generate_recursive(100)), id="recursive field"
+            lambda payload: _wrap_length_delimited(1, payload), id="recursive field"
         ),
         pytest.param(
-            Recursive(repeated_recursive=[generate_recursive(100) for _ in range(10)]),
-            id="repeated field",
+            lambda payload: _wrap_length_delimited(2, payload), id="repeated field"
         ),
         pytest.param(
-            Recursive(
-                map_recursive={str(i): generate_recursive(100) for i in range(10)}
-            ),
+            lambda payload: _wrap_length_delimited(3, _wrap_map_entry(payload)),
             id="map field",
         ),
     ],
 )
-def test_exceed_recursion_limit(msg: Recursive) -> None:
-    data = msg.to_binary()
+def test_exceed_recursion_limit(wrap_field: Callable[[bytes], bytes]) -> None:
+    # The serializer enforces the same depth limit, so serialize the deepest
+    # allowed message and wrap it in one more level of raw bytes.
+    data = wrap_field(generate_recursive(100).to_binary())
     with pytest.raises(
         RecursionError,
         match="exceeded maximum recursion depth 100 while parsing message",
@@ -253,7 +274,13 @@ def generate_recursive_msg(depth: int) -> DelimitedEncoding.Msg:
 
 
 def test_known_group_recursion_limit() -> None:
-    data = DelimitedEncoding(singular=generate_recursive_msg(100)).to_binary()
+    # The serializer enforces the same depth limit, so serialize the deepest
+    # allowed message and wrap it in one more group level of raw bytes.
+    w = BinaryWriter()
+    w.tag(2, WireType.SGROUP)
+    w.raw(generate_recursive_msg(100).to_binary())
+    w.tag(2, WireType.EGROUP)
+    data = w.finish()
 
     with pytest.raises(
         RecursionError,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -31,7 +31,7 @@ from .gen.json_enum_names_pb import JsonEnumNames, Season
 from .gen.json_names_pb import JsonNames
 from .gen.lists_pb import Lists
 from .gen.maps_pb import Maps
-from .gen.messages_pb import ExplicitFields, ImplicitFields, MixedFields
+from .gen.messages_pb import ExplicitFields, ImplicitFields, MixedFields, Recursive
 from .gen.oneofs_pb import Oneofs
 from .gen.scalars_pb import Scalars
 
@@ -789,3 +789,38 @@ def test_to_json_del_before_multibyte_char() -> None:
     text = msg.to_json()
     assert text.encode("utf-8").decode("utf-8") == text
     assert Scalars.from_json(text) == msg
+
+
+def generate_recursive(depth: int) -> Recursive:
+    if depth == 0:
+        return Recursive()
+    return Recursive(recursive=generate_recursive(depth - 1))
+
+
+def test_to_json_equals_recursion_limit() -> None:
+    msg = generate_recursive(100)
+    assert msg.to_json()
+
+
+def test_to_json_exceeds_recursion_limit() -> None:
+    msg = Recursive(recursive=generate_recursive(100))
+    with pytest.raises(
+        RecursionError,
+        match="exceeded maximum recursion depth 100 while serializing message",
+    ):
+        msg.to_json()
+
+
+def test_to_json_cyclic_message() -> None:
+    msg = Recursive()
+    msg.recursive = msg
+    with pytest.raises(
+        RecursionError,
+        match="exceeded maximum recursion depth 100 while serializing message",
+    ):
+        msg.to_json()
+    with pytest.raises(
+        RecursionError,
+        match="exceeded maximum recursion depth 100 while serializing message",
+    ):
+        message_to_json_value(msg)

--- a/tests/test_json_wkt.py
+++ b/tests/test_json_wkt.py
@@ -540,3 +540,23 @@ def _test_roundtrip(message: Message, expected: Any) -> None:
 
     roundtripped = type(message).from_json(json_str)
     assert roundtripped == message
+
+
+def test_to_json_cyclic_value() -> None:
+    value = Value()
+    value.kind = Oneof(field="list_value", value=ListValue(values=[value]))
+    with pytest.raises(
+        RecursionError,
+        match="exceeded maximum recursion depth 100 while serializing message",
+    ):
+        value.to_json()
+
+
+def test_to_json_cyclic_struct() -> None:
+    struct = Struct()
+    struct.fields = {"self": Value(kind=Oneof(field="struct_value", value=struct))}
+    with pytest.raises(
+        RecursionError,
+        match="exceeded maximum recursion depth 100 while serializing message",
+    ):
+        struct.to_json()

--- a/tests/test_to_binary.py
+++ b/tests/test_to_binary.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025-2026 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import pytest
+
+from .gen.delimited_encoding_pb import DelimitedEncoding
+from .gen.messages_pb import Recursive
+
+RECURSION_ERROR = "exceeded maximum recursion depth 100 while serializing message"
+
+
+def generate_recursive(depth: int) -> Recursive:
+    if depth == 0:
+        return Recursive()
+    return Recursive(recursive=generate_recursive(depth - 1))
+
+
+def generate_recursive_msg(depth: int) -> DelimitedEncoding.Msg:
+    if depth == 0:
+        return DelimitedEncoding.Msg()
+    return DelimitedEncoding.Msg(child=generate_recursive_msg(depth - 1))
+
+
+def test_equals_recursion_limit() -> None:
+    msg = generate_recursive(100)
+    assert Recursive.from_binary(msg.to_binary()) == msg
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        pytest.param(
+            Recursive(recursive=generate_recursive(100)), id="recursive field"
+        ),
+        pytest.param(
+            Recursive(repeated_recursive=[generate_recursive(100)]), id="repeated field"
+        ),
+        pytest.param(
+            Recursive(map_recursive={"a": generate_recursive(100)}), id="map field"
+        ),
+        pytest.param(
+            DelimitedEncoding(singular=generate_recursive_msg(100)), id="group field"
+        ),
+    ],
+)
+def test_exceed_recursion_limit(msg: Recursive | DelimitedEncoding) -> None:
+    with pytest.raises(RecursionError, match=RECURSION_ERROR):
+        msg.to_binary()
+
+
+@pytest.mark.parametrize("field", ["recursive", "repeated_recursive", "map_recursive"])
+def test_cyclic_message(field: str) -> None:
+    msg = Recursive()
+    match field:
+        case "recursive":
+            msg.recursive = msg
+        case "repeated_recursive":
+            msg.repeated_recursive = [msg]
+        case _:
+            msg.map_recursive = {"a": msg}
+    with pytest.raises(RecursionError, match=RECURSION_ERROR):
+        msg.to_binary()
+
+
+def test_cyclic_group() -> None:
+    msg = DelimitedEncoding.Msg()
+    msg.child = msg
+    with pytest.raises(RecursionError, match=RECURSION_ERROR):
+        msg.to_binary()

--- a/tests/test_unknown_fields.py
+++ b/tests/test_unknown_fields.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+import pytest
+
 from protobuf import (
     DescFieldValueEnum,
     DescFieldValueList,
@@ -23,7 +25,7 @@ from protobuf import (
     ScalarType,
 )
 from tests.gen.enums_pb import Color
-from tests.gen.messages_pb import ExplicitFields, ExplicitFieldsWithUnknowns
+from tests.gen.messages_pb import ExplicitFields, ExplicitFieldsWithUnknowns, Recursive
 
 desc_unknown_double_field = DescUnknownField(
     9990, DescFieldValueScalar(ScalarType.DOUBLE, default_value=0.0, oneof=None)
@@ -137,3 +139,20 @@ def test_unknown_fields_access() -> None:
     assert desc_unknown_repeated_field not in msg
     assert desc_unknown_map_field not in msg
     assert desc_unknown_message_field not in msg
+
+
+def test_set_cyclic_unknown_message_field() -> None:
+    desc_field = DescUnknownField(
+        9995,
+        DescFieldValueMessage(
+            message=Recursive.desc(), delimited_encoding=False, oneof=None
+        ),
+    )
+    value = Recursive()
+    value.recursive = value
+    msg = ExplicitFields()
+    with pytest.raises(
+        RecursionError,
+        match="exceeded maximum recursion depth 100 while serializing message",
+    ):
+        msg[desc_field] = value


### PR DESCRIPTION
We currently have a depth limit for parsing since that can be untrusted input. Serialization has a different issue where a user bug can assign a recursive message reference, which isn't that hard since for a recursive schema it would be type-safe. While this causing a `RecursionError` for pure python is probably acceptable without special handling, for native it is a segfault as the native stack overflows. Even user bugs must not result in segfaults.

Instead of expensive object ID tracking to find cycles, it is fine to use an almost-free depth limit on the serialization side like we have on the parse side. A side-benefit of doing this is that to_binary now can't produce output that from_binary would reject, they have the same limits.

This also adds validation of set extensions which was just missed before